### PR TITLE
Dostosowanie kursu do reguł języka polskiego

### DIFF
--- a/docs/A-podstawy-programowania/A1-pierwszy-program.md
+++ b/docs/A-podstawy-programowania/A1-pierwszy-program.md
@@ -19,14 +19,14 @@ Zaczynajmy!
 Programy, które będziemy tworzyć w tym kursie, po uruchomieniu otworzą konsolę.
 W takiej konsoli można programowi podać dane, po czym program się wykona i wypisze obliczone dane.
 
-Żebyśmy mogli napisać sami kod źródłowy, teoretycznie "wystarczy" najzwyklejszy notatnik na komputerze, a do skompilowania "wystarczy" pobrać i użyć kompilatora do języka C++.
+Żebyśmy sami mogli napisać kod źródłowy, teoretycznie "wystarczy" najzwyklejszy notatnik na komputerze, a do skompilowania "wystarczy" pobrać i użyć kompilatora do języka C++.
 Jak się niedługo okaże, kody źródłowe programów bywają na tyle skomplikowane, że lepiej jest skorzystać ze *środowiska programistycznego*.
 Takie środowisko zazwyczaj jest edytorem tekstu, który pomaga pisać kody źródłowe, oraz umożliwia łatwe kompilowanie i uruchamianie programu.
 
 Istnieje wiele środowisk programistycznych, a żeby ułatwić wybór, pokażemy jak zainstalować dwa konkretne, zależnie od preferencji:
 
-- Visual Studio Code - na tę chwilę najpopularniejsze środowisko programistyczne, które wspiera wiele języków programowania, w tym C++ oraz Python.
-- Geany - bardzo lekki edytor tekstu z minimalnym interfejsem do skompilowania i uruchamiania kodu.
+- Visual Studio Code – na tę chwilę najpopularniejsze środowisko programistyczne, które wspiera wiele języków programowania, w tym C++ oraz Python.
+- Geany – bardzo lekki edytor tekstu z minimalnym interfejsem do skompilowania i uruchamiania kodu.
 
 # Krok 1: Instalacja WSL oraz g++
 
@@ -53,7 +53,7 @@ aspect-ratio: 16 / 9;
 # Krok 2b: Instalacja Geany
 
 Instalator `geany-2.0_setup.exe` można pobrać ze strony [geany.org](https://www.geany.org/download/releases/).
-Kroki instalacyjne są prostsze, niż te dla Visual Studio Code.
+Kroki instalacyjne są prostsze niż te dla Visual Studio Code.
 
 <iframe src="https://www.youtube.com/embed/SnsaP3msEBQ?si=EcmGdGHOrwR6CZm_" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
@@ -101,7 +101,7 @@ Natomiast fragment `\n` występujący na końcu napisu `" w skali Fahrenheita\n"
 
 ## Zadania i system Szkopuł
 
-Na końcu każdej lekcji kursu mamy dla Ciebie zadania do samodzielnego rozwiązania. Będą powiązane z treściami lekcji, na początku będą bardzo proste
+Na końcu każdej lekcji kursu mamy dla Ciebie zadania do samodzielnego rozwiązania. Będą one powiązane z treściami lekcji i na początku bardzo proste.
 Rozwiązaniem każdego z zadań jest program (a dokładniej: kod źródłowy), który powinieneś zgłosić w serwisie [Szkopuł](https://szkopul.edu.pl/).
 Programy są oceniane w pełni automatycznie. **Zacznij zatem od założenia konta w tym systemie**.
 
@@ -119,12 +119,12 @@ McKinley - 6194 m n.p.m.
 Mont Blanc - 4810 m n.p.m.
 ````
 
-Pamiętaj, że aby twój program został zaakceptowany w systemie, należy wypisać **dokładnie** ten sam tekst co powyżej - bez żadnych dodatkowych znaków (w tym spacji). Nasza automatyczna sprawdzarka jest bardzo rygorystyczna i niezbyt domyślna. Napiszemy o niej więcej w lekcji "Technikalia, pierwsze zadania", na razie musisz
+Pamiętaj, że aby twój program został zaakceptowany w systemie, należy wypisać **dokładnie** ten sam tekst co powyżej – bez żadnych dodatkowych znaków (w tym spacji). Nasza automatyczna sprawdzarka jest bardzo rygorystyczna i niezbyt domyślna. Napiszemy o niej więcej w lekcji "Technikalia, pierwsze zadania", na razie musisz
 
 #### Wyjście
 
 Twój program powinien wypisać dokładnie podany wyżej komunikat.
 
-Kiedy Twój program będzie gotowy, zaloguj się na swoje konto w systemie Szkopuł, wybierz konkurs "Kurs OI", a następnie "Wyślij" i z listy zadań wybierz "Początek". Możesz też od razu (będąc zalogowanym w systemie Szkopuł) kliknąć w poniższy link:
+Kiedy Twój program będzie gotowy, zaloguj się na swoje konto w systemie Szkopuł, wybierz konkurs "Kurs OI", a następnie "Wyślij" i z listy zadań wybierz "Początek". Możesz też od razu (będąc zalogowanym w systemie Szkopuł) kliknąć poniższy link:
 
 [Sprawdź kod na Szkopule :fontawesome-solid-paper-plane:](https://szkopul.edu.pl/c/kurs-oi/p/#poc){ .md-button .md-button--primary }

--- a/docs/A-podstawy-programowania/A2-zmienne.md
+++ b/docs/A-podstawy-programowania/A2-zmienne.md
@@ -2,7 +2,7 @@
 
 ## Zmienne i wczytywanie
 
-W poprzedniej lekcji nauczyliśmy się wypisywać proste komunikaty oraz, w ostatnim przykładzie, liczby całkowite. Aby jednak robić cokolwiek bardziej skomplikowanego – choćby przyjmować dane od użytkownika, albo prowadzić obliczenia – potrzebujemy sposobu, aby przechowywać dane w pamięci komputera. Do takich celów służą **zmienne**. Pojedyncza zmienna to komórka pamięci komputera, której na jakiś czas nadajemy nazwę, i która może przechowywać jeden obiekt – na przykład liczbę całkowitą, albo napis złożony z liter.
+W poprzedniej lekcji nauczyliśmy się wypisywać proste komunikaty oraz, w ostatnim przykładzie, liczby całkowite. Aby jednak robić cokolwiek bardziej skomplikowanego – choćby przyjmować dane od użytkownika albo prowadzić obliczenia – potrzebujemy sposobu, aby przechowywać dane w pamięci komputera. Do takich celów służą **zmienne**. Pojedyncza zmienna to komórka pamięci komputera, której na jakiś czas nadajemy nazwę, i która może przechowywać jeden obiekt – na przykład liczbę całkowitą, albo napis złożony z liter.
 
 Najprostszym typem zmiennych są zmienne całkowite, czyli takie, które przechowują jedną liczbę całkowitą. Aby móc korzystać z takiej zmiennej, musimy ją w programie **zadeklarować**, czyli poinformować kompilator o chęci jej użycia oraz nadać nazwę. Deklaracja zmiennej całkowitej wygląda tak:
 
@@ -10,23 +10,23 @@ Najprostszym typem zmiennych są zmienne całkowite, czyli takie, które przecho
 int nazwa_zmiennej;
 ```
 
-Słowo ```int``` informuje kompilator, że zmienna jest właśnie typu całkowitego (ang. **integer**), zaś wybór nazwy należy do nas. Na przykład ```int moja_liczba;``` oznacza, że od tej pory w komórce o nazwie ```moja_liczba``` będzie przechowywana liczba całkowita. Możemy od momentu deklaracji użyć nazwy ```moja_liczba``` wszędzie tam, gdzie w programie mogłaby stać liczba. Na przykład:
+Słowo ```int``` informuje kompilator, że zmienna jest właśnie typu całkowitego (ang. **integer**), wybór nazwy zaś należy do nas. Na przykład ```int moja_liczba;``` oznacza, że od tej pory w komórce o nazwie ```moja_liczba``` będzie przechowywana liczba całkowita. Możemy od momentu deklaracji użyć nazwy ```moja_liczba``` wszędzie tam, gdzie w programie mogłaby stać liczba. Na przykład:
 
 ```C++
 cout << moja_liczba << "\n";
-``` 
+```
 
 to polecenie wypisania na ekran tego, co aktualnie jest w tej komórce, po czym przechodzi do nowego wiersza konsoli. Z kolei:
 
 ```C++
 moja_liczba = 7;
-``` 
+```
 oznacza "do komórki o nazwie ```moja_liczba``` wpisz liczbę ``7``". Zatem:
 
 ```C++
 moja_liczba = 7;
 cout << moja_liczba << "\n";
-``` 
+```
 po prostu wypisze na ekran liczbę ``7`` (czyli zadziała dokładnie tak, jak ```cout << 7```).
 
 Spróbujmy teraz sprawić, aby do zmiennej trafiła liczba, którą użytkownik wpisze z klawiatury. Wczytywanie wykonujemy instrukcją:
@@ -51,9 +51,9 @@ int main() {
 Jeżeli skompilujesz i uruchomisz ten program, to "zatrzyma się" on, oczekując, aż podasz mu (wpiszesz na klawiaturze)
 jakąś liczbę całkowitą, np. 123. Kiedy wpiszesz liczbę i naciśniesz ```Enter```, program wypisze liczbę wraz z
 komunikatem i zakończy działanie.
-Zauważ, że w przeciwieństwie do napisów-komunikatów, nazwy zmiennej nie umieszczamy w cudzysłowach: gdybyśmy napisali instrukcję ```cout << "moja_liczba"```, kompilator wypisałby na ekran po prostu napis ```moja_liczba``` (sprawdź!). Z kolei ```cin >> "moja_liczba"``` zakończyłoby się błędem kompilacji: kompilator nie rozumie, czemu wczytujemy dane do czegoś, co jego zdaniem nie jest zmienną.
+Zauważ, że w przeciwieństwie do napisów-komunikatów, nazwy zmiennej nie umieszczamy w cudzysłowie: gdybyśmy napisali instrukcję ```cout << "moja_liczba"```, kompilator wypisałby na ekran po prostu napis ```moja_liczba``` (sprawdź!). Z kolei ```cin >> "moja_liczba"``` zakończyłoby się błędem kompilacji: kompilator nie rozumie, czemu wczytujemy dane do czegoś, co jego zdaniem nie jest zmienną.
 
-W kolejnym programie wczytujemy i wypisujemy dwie liczby. Zauważ, że przy wypisywaniu musimy je jakoś rozdzielić, np. poprzez spację lub ```"\n"```. Natomiast program da sobie radę z ich wczytaniem niezależnie od tego, czy zostaną podane w tym samym wierszu czy w różnych wierszach, a także niezależnie od dodatkowych spacji wprowadzonych przez użytkownika.
+W kolejnym programie wczytujemy i wypisujemy dwie liczby. Zauważ, że przy wypisywaniu musimy je jakoś rozdzielić, np. poprzez spację lub ```"\n"```. Natomiast program da sobie radę z ich wczytaniem niezależnie od tego, czy zostaną podane w tym samym wierszu, czy w różnych wierszach, a także niezależnie od dodatkowych spacji wprowadzonych przez użytkownika.
 
 ```C++
 #include <iostream>
@@ -67,7 +67,7 @@ int main() {
 }
 ```
 
-Jak już wspomnieliśmy, po wczytaniu zmiennych całkowitych możemy traktować je w programie dokładnie tak, jak same liczby, w szczególności wykonywać na nich działania. Poniższy program wczytuje długości boków prostokąta i oblicza pole i obwód tego prostokąta. 
+Jak już wspomnieliśmy, po wczytaniu zmiennych całkowitych możemy traktować je w programie dokładnie tak, jak same liczby, w szczególności wykonywać na nich działania. Poniższy program wczytuje długości boków prostokąta i oblicza pole i obwód tego prostokąta.
 
 ```C++
 #include <iostream>
@@ -142,7 +142,7 @@ Należy wiedzieć o kilku ograniczeniach dotyczących nazw zmiennych. Nazwa zmie
 
 Deklaracja zmiennej może zostać umieszczona w programie w dowolnym miejscu przed miejscem, w którym chcemy ze zmiennej skorzystać (czyli np. wczytać lub wypisać jej wartość). Nazwy zmiennych nie mogą się powtarzać (wyjątki od tego ostatniego stwierdzenia przedstawimy później).
 
-Poniższy program oblicza pole i obwód prostokąta dokładnie tak samo jak poprzedni. Jest on jednak istotnie mniej czytelny.
+Poniższy program oblicza pole i obwód prostokąta dokładnie tak samo, jak poprzedni. Jest on jednak istotnie mniej czytelny.
 
 ```C++
 #include <iostream>

--- a/docs/A-podstawy-programowania/A3-technikalia-zadania.md
+++ b/docs/A-podstawy-programowania/A3-technikalia-zadania.md
@@ -6,7 +6,7 @@ Wiemy już, że kompilator języka C++ jest pod wieloma względami dosyć restry
 Radzenie sobie z takimi błędami często jest całkiem proste – trzeba przeczytać treść błędu zgłoszonego przez
 kompilator i poprawić odpowiedni fragment kodu. Jeśli kompilacja nie udała się, środowisko programistyczne wypisze komunikat z opisem błędu, który zazwyczaj też zawiera numer wiersza, który spowodował błąd.
 
-Dla przykładu, przepiszemy nasz wcześniejszy program obliczający pole i obwód prostokąta, umieszczając w nim pewne usterki, które najczęściej przydarzają się początkującym programistom, i przyjrzymy się występującym błędom kompilacji. Oto pierwsza błędna wersja:
+Dla przykładu przepiszemy nasz wcześniejszy program obliczający pole i obwód prostokąta, umieszczając w nim pewne usterki, które najczęściej przydarzają się początkującym programistom, i przyjrzymy się występującym błędom kompilacji. Oto pierwsza błędna wersja:
 
 ```C++
 #include <iostream>
@@ -111,13 +111,13 @@ Co się stanie, jeśli "złośliwy" użytkownik wpisze z klawiatury liczby ``10`
 
 Jest to tak zwany **błąd wykonania** programu – program wykonał operację, po której nie może już działać dalej. Dzielenie przez zero to tylko jeden z przykładów, znacznie częściej spotkasz się z błędem wykonania, kiedy zaczniesz działać na tablicach, wskaźnikach, lub innych bardziej skomplikowanych zmiennych.
 
-Oczywiście nawet jeśli nasz program poprawnie się skompiluje, są inne powody, dla których może nie działać tak, jak chcemy. Może dawać w wyniku niewłaściwe (błędne) odpowiedzi, może też działać w nieskończoność i się nie kończyć (co nazywamy *zapętleniem* lub *zawieszeniem*). Sposoby radzenia sobie z poszczególnymi typami błędów będziemy przedstawiać w częściach technicznych kolejnych lekcji.
+Oczywiście, nawet jeśli nasz program poprawnie się skompiluje, są inne powody, dla których może nie działać tak, jak chcemy. Może dawać w wyniku niewłaściwe (błędne) odpowiedzi, może też działać w nieskończoność i się nie kończyć (co nazywamy *zapętleniem* lub *zawieszeniem*). Sposoby radzenia sobie z poszczególnymi typami błędów będziemy przedstawiać w częściach technicznych kolejnych lekcji.
 
 ## Zadania
 
 W tej lekcji mamy dla Ciebie trzy zadania. W każdym zadaniu, w sekcji "Wejście" znajduje się opis danych, które program ma wczytać, natomiast w sekcji "Wyjście" podano wymagany sposób wypisania wyniku. Twoje rozwiązanie zostanie sprawdzone automatycznie z użyciem pewnej liczby **testów**, czyli różnych zestawów danych wejściowych (możesz to sobie wyobrazić tak, że nasz automat uruchamia Twój program, "wpisuje" odpowiednie dane i sprawdza wynik jego działania). W każdym teście dane wejściowe są idealnie zgodne z opisem podanym w sekcji "Wejście", a wynik Twojego programu musi dokładnie odpowiadać temu, co jest opisane w sekcji "Wyjście". Jak wspominaliśmy poprzednio, dopuszczalne są nadmiarowe spacje na końcach wierszy i puste wiersze na końcu wyjścia. Program nie może wypisywać **żadnych** dodatkowych komunikatów, o które nie jest proszony w treści zadania. Twój program zostanie uznany za poprawny, jeśli zadziała poprawnie na **wszystkich** naszych testach.
 
-Zalacamy, żeby wszystkie zadania rozwiązywać samodzielnie. Jeśli chcesz, możesz przy rozwiązywaniu wyszukiwać dodatkowe informacje w Internecie lub zasięgnąć pomocy u nauczyciela czy kolegów. Ważne jednak, aby cały kod był napisany przez Ciebie – tylko tak będziesz w stanie zdobyć umiejętności, dzięki którym będziesz się mógł zabrać za bardziej skomplikowane problemy.
+Zalecamy, żeby wszystkie zadania rozwiązywać samodzielnie. Jeśli chcesz, możesz przy rozwiązywaniu wyszukiwać dodatkowe informacje w Internecie lub zasięgnąć pomocy u nauczyciela czy kolegów. Ważne jednak, aby cały kod był napisany przez Ciebie – tylko tak będziesz w stanie zdobyć umiejętności, dzięki którym będziesz się mógł zabrać za bardziej skomplikowane problemy.
 
 A oto obiecane zadania – powodzenia!
 

--- a/docs/A-podstawy-programowania/A4-warunki.md
+++ b/docs/A-podstawy-programowania/A4-warunki.md
@@ -97,7 +97,7 @@ else {
 }
 ```
 
-Oznacza to, że jeśli _warunek1_ jest spełniony, to wykonywana jest _instrukcja1_. W przeciwnym razie, jeśli _warunek2_ jest spełniony, wykonywana jest _instrukcja2_, podobnie z _warunkiem3_ i _instrukcją3_. Jeśli żaden z warunków nie był spełniony, wykonywana jest _instrukcja4_. Można także pominąć końcowy `else` w tej instrukcji. Wówczas jeśli żaden z warunków nie jest spełniony, nie jest wykonywana żadna instrukcja. W szczególności, instrukcja if może mieć następującą, najbardziej uproszczoną postać:
+Oznacza to, że jeśli _warunek1_ jest spełniony, to wykonywana jest _instrukcja1_. W przeciwnym razie, jeśli _warunek2_ jest spełniony, wykonywana jest _instrukcja2_, podobnie z _warunkiem3_ i _instrukcją3_. Jeśli żaden z warunków nie był spełniony, wykonywana jest _instrukcja4_. Można także pominąć końcowy `else` w tej instrukcji. Wówczas jeśli żaden z warunków nie jest spełniony, nie jest wykonywana żadna instrukcja. W szczególności instrukcja `if` może mieć następującą, najbardziej uproszczoną postać:
 
 ```cpp
 if (warunek) {
@@ -105,7 +105,7 @@ if (warunek) {
 }
 ```
 
-Wtedy jeśli _warunek_ nie jest spełniony, żadna instrukcja nie jest wykonywana, czyli po prostu nic się nie dzieje.
+Wtedy, jeśli _warunek_ nie jest spełniony, żadna instrukcja nie jest wykonywana, czyli po prostu nic się nie dzieje.
 
 Jako kolejny przykład napiszmy program, który wczytuje liczbę całkowitą i wypisuje jej znak: "+" jeśli jest dodatnia, "-" jeśli jest ujemna, a "0" jeśli jest zerem.
 
@@ -133,7 +133,7 @@ int main() {
 
 W opisie warunku możemy także używać tzw. spójników logicznych: **i**, **lub** oraz **nie**, zapisywanych w C++ jako `&&`, `||` oraz `!`. Za pomocą spójników `&&` oraz `||` możemy łączyć dwa warunki lub więcej. Znak `!` możemy postawić przed jakimś warunkiem, umieszczając ten warunek w nawiasach.
 
-**Uwaga:** Znak **&** (ang. _ampersand_) jest na tym samym klawiszu co siódemka. Natomiast znak I (kreska pionowa _, pałka_) jest na tym samym klawiszu co **\**.
+**Uwaga:** Znak **&** (ang. _ampersand_) jest na tym samym klawiszu co siódemka. Natomiast znak | (kreska pionowa _, pałka_) jest na tym samym klawiszu co **\**.
 
 Napiszmy teraz program, który sprawdzi, czy trójkąt o danych trzech bokach jest równoboczny, równoramienny czy różnoboczny:
 
@@ -160,9 +160,9 @@ int main() {
 
 **Uwaga:** Warto zwrócić szczególną uwagę na to, że w języku C++ do sprawdzania równości w warunkach używa się **dwuznaku `==`**. Pojedynczy znak równości oznacza operację _przypisania_, którą widzieliśmy już wcześniej, a której będzie poświęcona następna lekcja kursu. Jeśli w warunku napiszemy `=` zamiast `==`, program skompiluje się, ale nie będzie działał poprawnie!
 
-W jednym warunku możemy użyć różnych typów spójników logicznych. Jednak trzeba wiedzieć, że operatory `&&` i `||` nie są równoważne pod względem pierwszeństwa - operator `&&` ma wyższe pierwszeństwo niż `||`. Aby nie musieć o tym pamiętać i uniknąć zamieszania, poszczególne fragmenty wyrażenia najlepiej umieszczać w nawiasach.
+W jednym warunku możemy użyć różnych typów spójników logicznych. Jednak trzeba wiedzieć, że operatory `&&` i `||` nie są równoważne pod względem pierwszeństwa – operator `&&` ma wyższe pierwszeństwo niż `||`. Aby nie musieć o tym pamiętać i uniknąć zamieszania, poszczególne fragmenty wyrażenia najlepiej umieszczać w nawiasach.
 
-Aby zilustrować łączenie warunków, napiszmy program, który wczyta rok i wypisze liczbę dni w tym roku. Rok ma 365 dni, no może, że jest przestępny - wówczas ma 366 dni. Rok jest przestępny, jeśli dzieli się przez 4. Jeśli jednak dzieli się przez 100, to nie jest przestępny. Wyjątkiem jest sytuacja, gdy rok dzieli się przez 400 - wówczas mimo wszystko jest przestępny (patrz [Wikipedia](http://pl.wikipedia.org/wiki/Rok_przest%C4%99pny "Wikipedia")). Sprawdzanie podzielności w C++ możemy zrealizować za pomocą operatora reszty z dzielenia "%". Oto program:
+Aby zilustrować łączenie warunków, napiszmy program, który wczyta rok i wypisze liczbę dni w tym roku. Rok ma 365 dni, no może, że jest przestępny – wówczas ma 366 dni. Rok jest przestępny, jeśli dzieli się przez 4. Jeśli jednak dzieli się przez 100, to nie jest przestępny. Wyjątkiem jest sytuacja, gdy rok dzieli się przez 400 - wówczas mimo wszystko jest przestępny (patrz [Wikipedia](http://pl.wikipedia.org/wiki/Rok_przest%C4%99pny "Wikipedia")). Sprawdzanie podzielności w C++ możemy zrealizować za pomocą operatora reszty z dzielenia "%". Oto program:
 
 ```cpp
 #include <iostream>
@@ -188,7 +188,7 @@ int main() {
 
 ## Instrukcje złożone
 
-W ramach instrukcji `if` mogą występować także tzw. **instrukcje złożone**, czyli składające się z kilku pojedynczych instrukcji. Wśród tych pojedynczych instrukcji mogą występować np. wczytywania, wypisywania, kolejne instrukcje warunkowe `if`, a także instrukcje, które poznamy w kolejnych lekcjach. Instrukcję złożoną otacza się nawiasami klamrowymi { } i może ona występować w dowolnym bloku `if` czy w bloku `else` (może też być w kilku z nich - nie ma tu ograniczeń). W najprostszej postaci wygląda to tak:
+W ramach instrukcji `if` mogą występować także tzw. **instrukcje złożone**, czyli składające się z kilku pojedynczych instrukcji. Wśród tych pojedynczych instrukcji mogą występować np. wczytywania, wypisywania, kolejne instrukcje warunkowe `if`, a także instrukcje, które poznamy w kolejnych lekcjach. Instrukcję złożoną otacza się nawiasami klamrowymi { } i może ona występować w dowolnym bloku `if` czy w bloku `else` (może też być w kilku z nich – nie ma tu ograniczeń). W najprostszej postaci wygląda to tak:
 
 ```cpp
 if (warunek1) {
@@ -225,7 +225,7 @@ Tym razem zastanowimy się nad tym, co robić, kiedy napisany przez nas program 
 
 Gorszą sytuacją jest, gdy nasz program nie działa i **nie wiemy**, dla jakich danych się to dzieje. Ma to miejsce np. wówczas, gdy wysyłamy program do systemu sprawdzającego i dostajemy informację, że program dał błędną odpowiedź, ale nie widzimy konkretnych danych testowych. Warto na początku upewnić się, czy program wypisuje dane **dokładnie** tak, jak to zostało opisane w treści zadania. Np. jeśli program ma wypisać jakieś liczby w jednym wierszu, nie mogą one być umieszczone w różnych wierszach. Nie są też tolerowane żadne dodatkowe komunikaty na wyjściu. Jedyne dopuszczalne odstępstwo to dodatkowe spacje na samym końcu wiersza lub dodatkowe puste wiersze na końcu wyjścia.
 
-Jeśli upewniliśmy się, że nie popełniliśmy żadnego z tych podstawowych błędów, musimy znaleźć jakieś inne wyjście z sytuacji. Jak opisaliśmy wyżej, warto przeczytać kod źródłowy programu - a nuż uda nam się w tej sposób wychwycić usterkę. Jeśli nie, powinniśmy spróbować znaleźć jakieś dane testowe, dla których program nie działa poprawnie. Możemy spróbować wpisać _jakieś_ dane do programu i mieć nadzieję, że akurat uda się wychwycić usterkę. Dużo pewniejszą drogą jest próba _systematycznego_ przejrzenia różnych rodzajów danych wejściowych (zazwyczaj nie da się sprawdzić wszystkich możliwych danych wejściowych, gdyż jest ich zbyt dużo).
+Jeśli upewniliśmy się, że nie popełniliśmy żadnego z tych podstawowych błędów, musimy znaleźć jakieś inne wyjście z sytuacji. Jak opisaliśmy wyżej, warto przeczytać kod źródłowy programu – a nuż uda nam się w tej sposób wychwycić usterkę. Jeśli nie, powinniśmy spróbować znaleźć jakieś dane testowe, dla których program nie działa poprawnie. Możemy spróbować wpisać _jakieś_ dane do programu i mieć nadzieję, że akurat uda się wychwycić usterkę. Dużo pewniejszą drogą jest próba _systematycznego_ przejrzenia różnych rodzajów danych wejściowych (zazwyczaj nie da się sprawdzić wszystkich możliwych danych wejściowych, gdyż jest ich zbyt dużo).
 
 Prześledźmy to na przykładzie.
 
@@ -252,7 +252,7 @@ int main() {
 }
 ```
 
-**Uwaga:** Zakładamy, że w tym programie nie musimy przejmować się tym, czy istnieje trójkąt o podanych długościach boków. Sprawdzanie tego warunku pozostawiamy Tobie do samodzielnego rozwiązania w jednym z zadań domowych do lekcji.
+**Uwaga:** Zakładamy, że w tym programie nie musimy przejmować się tym, czy istnieje trójkąt o podanych długościach boków. Sprawdzanie tego warunku pozostawiamy Ci do samodzielnego rozwiązania w jednym z zadań domowych do lekcji.
 
 Spróbujmy podać programowi dane odpowiadające różnym typom trójkątów i sprawdźmy, czy wynik był poprawny. Widać, że konkretne liczby nie mają tu większego znaczenia. Wystarczy zatem sprawdzić wszystkie różne _typy_ trójkątów. Wpisujemy kolejno dane wejściowe:
 
@@ -307,7 +307,7 @@ Ogólnie problem błędnych odpowiedzi jest jednym z najczęstszych zagadnień, 
 ## Zadania
 
 W tej lekcji mamy dla Ciebie do rozwiązania trzy zadania dotyczące instrukcji warunkowej `if`.
-Dodatkowo, dla uczestników lubiących wyzwania i zainteresowanych przygotowaniem do olimpiad mamy przygotowane nieco trudniejsze zadanie "z gwiazdką".
+Co więcej, dla uczestników lubiących wyzwania i zainteresowanych przygotowaniem do olimpiad mamy przygotowane nieco trudniejsze zadanie "z gwiazdką".
 
 [Maksimum :fontawesome-solid-paper-plane:](https://szkopul.edu.pl/c/kurs-oi/p/#max){ .md-button .md-button--primary }
 

--- a/docs/A-podstawy-programowania/A5-przypisanie.md
+++ b/docs/A-podstawy-programowania/A5-przypisanie.md
@@ -2,7 +2,7 @@
 
 # Część programistyczna: Instrukcja przypisania
 
-W tej lekcji opowiemy o podstawowej metodzie nadawania wartości zmiennym -- instrukcji **przypisania**. W najprostszej wersji już ją widzieliśmy: aby nadać zmiennej $a$ typu `int` wartość (na przykład) 5, możemy użyć następującej instrukcji:
+W tej lekcji opowiemy o podstawowej metodzie nadawania wartości zmiennym – instrukcji **przypisania**. W najprostszej wersji już ją widzieliśmy: aby nadać zmiennej $a$ typu `int` wartość (na przykład) 5, możemy użyć następującej instrukcji:
 
 ```cpp
 a = 5;
@@ -14,7 +14,7 @@ Przypisania tego typu stosuje się w szczególności do ustawienia początkowej 
 int a = 5;
 ```
 
-Zamiast pojedynczej liczby w przypisaniu może także wystąpić dowolne wyrażenie matematyczne. Na przykład: 
+Zamiast pojedynczej liczby w przypisaniu może także wystąpić dowolne wyrażenie matematyczne. Na przykład:
 
 ```cpp
 int a, x, y;
@@ -22,13 +22,13 @@ cin >> x >> y;
 a = 2 * x * y + 1;
 ```
 
-Zmiennym możemy (oczywiście) wielokrotnie przypisywać różne wartości. To uzasadnia, dlaczego nazywamy je właśnie _zmiennymi_. Co ciekawe, zmienna, której przypisujemy nową wartość, może wystąpić także w wyrażeniu po prawej stronie instrukcji przypisania! Oto (bardzo typowa) przykładowa instrukcja: 
+Zmiennym możemy (oczywiście) wielokrotnie przypisywać różne wartości. To uzasadnia, dlaczego nazywamy je właśnie _zmiennymi_. Co ciekawe, zmienna, której przypisujemy nową wartość, może wystąpić także w wyrażeniu po prawej stronie instrukcji przypisania! Oto (bardzo typowa) przykładowa instrukcja:
 
 ```cpp
 a = a + 3;
 ```
 
-Jesteśmy przyzwyczajeni do tego, że znak ``=`` oznacza równość dwóch wartości, więc na pierwszy rzut oka taki zapis wydaje się nie mieć sensu -- żadna liczba nie może być równa sobie samej zwiększonej o $3$! Ale w C++, jak również w wielu innych językach programowania znak ``=`` **nie jest równością, a poleceniem wstawienia wartości do odpowiedniej komórki**. Instrukcja ``a = a + 3`` jest interpretowana następująco: weź aktualną wartość zmiennej ``a``, dodaj do niej 3, a potem otrzymany wynik wpisz z powrotem do komórki oznaczonej ``a``. Innymi słowym, będzie to zwiększenie wartości zmiennej $a$ o 3.
+Jesteśmy przyzwyczajeni do tego, że znak ``=`` oznacza równość dwóch wartości, więc na pierwszy rzut oka taki zapis wydaje się nie mieć sensu – żadna liczba nie może być równa sobie samej zwiększonej o $3$! Ale w C++, jak również w wielu innych językach programowania znak ``=`` **nie jest równością, a poleceniem wstawienia wartości do odpowiedniej komórki**. Instrukcja ``a = a + 3`` jest interpretowana następująco: weź aktualną wartość zmiennej ``a``, dodaj do niej 3, a potem otrzymany wynik wpisz z powrotem do komórki oznaczonej ``a``. Innymi słowy, będzie to zwiększenie wartości zmiennej $a$ o 3.
 
 Załóżmy na przykład, że chcemy wczytać pewną liczbę, dodać do niej 3, pomnożyć przez 2, a następnie dodać jeszcze 1, po każdej operacji wypisując aktualną wartość. Prosty program realizujący te zadania wyglądać może tak:
 
@@ -56,7 +56,7 @@ d = c + 1;
 cout << d;
 ```
 
-Na ogół jest to spowodowane "nieufnością" do instrukcji postaci ``a = a+3``. Postaraj się jak najszybciej pozbyć wątpliwości -- wkrótce przekonasz się, że deklarowanie wielu dodatkowych, niepotrzebnych zmiennych na dłuższą metę przeszkadza znacznie bardziej.
+Na ogół jest to spowodowane "nieufnością" do instrukcji postaci ``a = a+3``. Postaraj się jak najszybciej pozbyć wątpliwości – wkrótce przekonasz się, że deklarowanie wielu dodatkowych, niepotrzebnych zmiennych na dłuższą metę przeszkadza znacznie bardziej.
 
 
 ## Skrócone instrukcje przypisania
@@ -101,7 +101,7 @@ a++; // to samo co: a += 1;
 a--; // to samo co: a -= 1;
 ```
 
-Do pierwszej z tych instrukcji nawiązuje sama nazwa języka [C++](http://pl.wikipedia.org/wiki/C%2B%2B "C++"), który został zaprojektowany jako rozszerzenie starszego języka programowania [C](http://pl.wikipedia.org/wiki/C_%28j%C4%99zyk_programowania%29 "C"). Co ciekawe, poprzednikiem języka C był język [B](http://pl.wikipedia.org/wiki/B_%28j%C4%99zyk_programowania%29 "B"). 
+Do pierwszej z tych instrukcji nawiązuje sama nazwa języka [C++](http://pl.wikipedia.org/wiki/C%2B%2B "C++"), który został zaprojektowany jako rozszerzenie starszego języka programowania [C](http://pl.wikipedia.org/wiki/C_%28j%C4%99zyk_programowania%29 "C"). Co ciekawe, poprzednikiem języka C był język [B](http://pl.wikipedia.org/wiki/B_%28j%C4%99zyk_programowania%29 "B").
 
 A oto inny przykład. Zobaczymy, jak zastosowanie instrukcji przypisania może uprościć rozwiązanie zadania _Czas_ z lekcji "Błędy w programach, pierwsze zadania". Przypomnijmy, że należało w nim przeliczyć czas $t$ sekund na zapis w godzinach, minutach i sekundach.
 
@@ -172,7 +172,7 @@ Każdy ze znaków typu `char` ma przypisany numer będący liczbą całkowitą. 
 | 50   | 2               | 70   | F    | 90   | Z    | 110  | n    |      |                |
 
 
-Oczywiście nie trzeba pamiętać kodów ASCII poszczególnych znaków. Warto jedynie wiedzieć, że małe litery oraz wielkie litery alfabetu angielskiego (łacińskiego) są ustawione w kodzie kolejno w porządku alfabetycznym, a cyfry – od najmniejszej do największej. Porównywanie znaków typu `char` za pomocą operatorów <, <=, >, >= odbywa się według kodów ASCII, tak więc małe litery oraz wielkie litery są porównywane alfabetycznie, a cyfry od najmniejszej do największej. Znaki o kodach od 0 do 31 oraz znak o kodzie 127 to tzw. kody sterujące. Znajdują się wśród nich m.in. znaki końca wiersza i tabulacji; wiele z tych znaków wyszło już z użycia.
+Oczywiście nie trzeba pamiętać kodów ASCII poszczególnych znaków. Warto jedynie wiedzieć, że małe litery oraz wielkie litery alfabetu angielskiego (łacińskiego) są ustawione w kodzie kolejno w porządku alfabetycznym, a cyfry – od najmniejszej do największej. Porównywanie znaków typu `char` za pomocą operatorów `<`, `<=`, `>`, `>=` odbywa się według kodów ASCII, tak więc małe litery oraz wielkie litery są porównywane alfabetycznie, a cyfry od najmniejszej do największej. Znaki o kodach od 0 do 31 oraz znak o kodzie 127 to tzw. kody sterujące. Znajdują się wśród nich m.in. znaki końca wiersza i tabulacji; wiele z tych znaków wyszło już z użycia.
 
 Wartości zmiennych typu `char` możemy więc traktować jako niewielkie liczby całkowite. Dokładniej, zmienna typu `char` przyjmuje wartości od -128 do 127, przy czym wartości nieujemne odpowiadają znakom kodu ASCII, a pozostałe mogą służyć do reprezentowania innych symboli (np. polskich znaków ą, ę, ź, ć itp. w niektórych _kodowaniach_). Typ `char` jest więc typem całkowitym jednobajtowym, którego brakowało w komentarzu do lekcji 2. Odpowiadającym mu typem całkowitym nieujemnym (o wartościach od 0 do 255) jest typ `unsigned char`.
 
@@ -221,7 +221,7 @@ char znak;
 cout << (int)znak << endl;
 ```
 
-Trochę więcej o konwersjach opowiemy w następnych lekcjach. Tymczasem jeszcze jeden, "złośliwy" przykład. Powiedzmy, że chcielibyśmy napisać program, który wczyta liczbę $i$ i wypisze $i$-tą małą literę alfabetu angielskiego (a zatem $i \in \{1,\ldots,26\}$, bowiem alfabet angielski ma 26 liter). Moglibyśmy to próbować zrobić tak:
+Trochę więcej o konwersjach opowiemy w następnych lekcjach. Tymczasem jeszcze jeden, "złośliwy" przykład. Powiedzmy, że chcielibyśmy napisać program, który wczyta liczbę $i$ i wypisze $i$-tą małą literę alfabetu angielskiego (a zatem $i \in \{1,\ldots,26\}$, alfabet angielski ma bowiem 26 liter). Moglibyśmy to próbować zrobić tak:
 
 ```cpp
 int numer;
@@ -239,7 +239,7 @@ cout << (char)('a' + numer - 1);
 
 # Zadania
 
-W tej lekcji, oprócz trzech "standardowych" zadań mamy również przygotowane jedno "z gwiazdką", nieco trudniejsze. Jeśli nie potrafisz go jeszcze rozwiązać, nie przejmuj się! 
+W tej lekcji, oprócz trzech "standardowych" zadań mamy również przygotowane jedno "z gwiazdką", nieco trudniejsze. Jeśli nie potrafisz go jeszcze rozwiązać, nie przejmuj się!
 
 [Łańcuszek :fontawesome-solid-paper-plane:](https://szkopul.edu.pl/c/kurs-oi/p/#lan){ .md-button .md-button--primary }
 

--- a/docs/A-podstawy-programowania/A6-while.md
+++ b/docs/A-podstawy-programowania/A6-while.md
@@ -2,7 +2,7 @@
 
 ## Część programistyczna: Pętla while
 
-Jak wiadomo, komputery potrafią wykonywać miliony instrukcji w ułamku sekundy. Ale jak je do tego zmusić? Gdybyśmy chcieli używać tylko dotychczas poznanych instrukcji, musielibyśmy fizycznie zapisać je milion razy. Jest zatem oczywiste, że potrzebujemy czegoś, co pozwoli nam na wprowadzenie do programu jakiegoś rodzaju powtarzania instrukcji. Takie konstrukcje nazywają się *pętlami* (ang. *loop*), a na tej lekcji poznamy pierwszą z nich – pętlę `while`, zwaną po polsku czasem (*pętlą "dopóki"*).
+Jak wiadomo, komputery potrafią wykonywać miliony instrukcji w ułamku sekundy, ale jak je do tego zmusić? Gdybyśmy chcieli używać tylko dotychczas poznanych instrukcji, musielibyśmy fizycznie zapisać je milion razy. Jest zatem oczywiste, że potrzebujemy czegoś, co pozwoli nam na wprowadzenie do programu jakiegoś rodzaju powtarzania instrukcji. Takie konstrukcje nazywają się *pętlami* (ang. *loop*), a na tej lekcji poznamy pierwszą z nich – pętlę `while`, zwaną po polsku czasem (*pętlą "dopóki"*).
 
 
 Pętla `while` w języku C++ wygląda następująco:
@@ -15,7 +15,7 @@ while (warunek)
 
 Jest ona z wyglądu dosyć podobna do instrukcji `if`. _Warunek_ jest warunkiem logicznym (czyli przyjmującym wartość `true` lub `false`), natomiast _instrukcja_ jest pojedynczą instrukcją lub (częściej) instrukcją złożoną, czyli grupą kilku instrukcji umieszczonych w nawiasach klamrowych ``{ ... }``. Pętla `while` wykonuje kolejne _obroty_. W każdym obrocie najpierw jest sprawdzany _warunek_. Jeśli jest on prawdziwy, wykonywana jest _instrukcja_, a w przeciwnym razie pętla kończy się. Czyli jeśli _warunek_ jest prawdziwy, wykonujemy _instrukcję_, po czym znów sprawdzamy _warunek_ – jeśli jest spełniony, znów wykonujemy _instrukcję_ i tak dalej – aż do chwili, gdy po wykonaniu _instrukcji_ _warunek_ nie będzie już spełniony. 
 
-Można zatem pętlę `while` odczytać tak: "dopóki jest spełniony _warunek_, wykonuj _instrukcję_". Trzeba jednak zawsze pamiętać o krokowym charakterze tej pętli: sprawdzenie warunku - wykonanie instrukcji - sprawdzenie warunku - wykonanie instrukcji - ...
+Można zatem pętlę `while` odczytać tak: "dopóki jest spełniony _warunek_, wykonuj _instrukcję_". Trzeba jednak zawsze pamiętać o krokowym charakterze tej pętli: sprawdzenie warunku – wykonanie instrukcji – sprawdzenie warunku – wykonanie instrukcji – ...
 
 Za pomocą pętli `while` możemy np. wypisać dowolnie wiele liczb. Na przykład wszystkie liczby od 1 do 10:
 
@@ -49,7 +49,7 @@ while (i <= 10) {
 Jeśli zaś _warunek_ jest zawsze prawdziwy, pętla obraca się w nieskończoność (o tym drugim przypadku więcej opowiemy w komentarzu).
 
 
-Na naszą przykładową pętlę można spojrzeć jako na ciąg złożony z wielu przypisań. Zmienna $i$ zmienia się w każdym obrocie pętli -- taką zmienną nazywamy   **zmienną sterująca** pętli, jako że od niej zależy liczba obrotów pętli. Bez problemu napiszemy teraz program, który wypisze wyłącznie liczby parzyste z zakresu od 0 do 20 włącznie, od największej do najmniejszej:
+Na naszą przykładową pętlę można spojrzeć jako na ciąg złożony z wielu przypisań. Zmienna $i$ zmienia się w każdym obrocie pętli – taką zmienną nazywamy **zmienną sterująca** pętli, jako że od niej zależy liczba obrotów pętli. Bez problemu napiszemy teraz program, który wypisze wyłącznie liczby parzyste z zakresu od 0 do 20 włącznie, od największej do najmniejszej:
 
 ```cpp
 #include <iostream>
@@ -80,9 +80,9 @@ int main() {
 }
 ```
 
-Jako kolejny przykład użyjemy teraz pętli `while`, aby wczytać z klawiatury wiele liczb, a następnie wszystkie je zsumować. Musimy w tym celu wiedzieć, kiedy wpisywanie liczb z klawiatury się zakończy – załóżmy tutaj, że sumowane liczby będą dodatnie, a liczba 0 oznacza koniec wpisywania. To będzie warunek zakończenia naszej pętli. 
+Jako kolejny przykład użyjemy teraz pętli `while`, aby wczytać z klawiatury wiele liczb, a następnie wszystkie je zsumować. Musimy w tym celu wiedzieć, kiedy wpisywanie liczb z klawiatury się zakończy – załóżmy tutaj, że sumowane liczby będą dodatnie, a liczba 0 oznacza koniec wpisywania. To będzie warunek zakończenia naszej pętli.
 
-Użyjemy jednej, zawsze tej samej zmiennej $a$, aby wczytywać kolejne liczby, zaś zaraz po wczytaniu wartość $a$ będziemy dodawać do sumy:
+Użyjemy jednej, zawsze tej samej zmiennej $a$, aby wczytywać kolejne liczby, zaraz po wczytaniu zaś wartość $a$ będziemy dodawać do sumy:
 
 ```cpp
 #include <iostream>
@@ -169,13 +169,13 @@ int main() {
 }
 ```
 
-Dodamy jeszcze, że w niektórych z powyższych przykładów pętla `while` wcale nie była najwygodniejszym rozwiązaniem! W kolejnych lekcjach poznamy inny rodzaj pętli, który pozwala wczytywać i wypisywać zadaną liczbę zmiennych w nieco wygodniejszy sposób (pętlę `for`), a także metodę przechowywania wielu zmiennych naraz (**tablice**). Ale nie warto robić wszystkiego naraz! Dobre zrozumienie pętli `while` jest już i tak nie lada wyzwaniem.
+Dodamy jeszcze, że w niektórych z powyższych przykładów pętla `while` wcale nie była najwygodniejszym rozwiązaniem! W kolejnych lekcjach poznamy inny rodzaj pętli, który pozwala wczytywać i wypisywać zadaną liczbę zmiennych w nieco wygodniejszy sposób (pętlę `for`), a także metodę przechowywania wielu zmiennych naraz (**tablice**). Jednak nie warto robić wszystkiego naraz! Dobre zrozumienie pętli `while` jest już i tak nie lada wyzwaniem.
 
 
 
 ## Część techniczna: Błędne odpowiedzi cz. 2
 
-W części technicznej kontynuujemy temat radzenia sobie z błędnymi odpowiedziami naszych programów. Tym razem założymy, że wiemy, dla jakich danych wejściowych program nie działa, i musimy zlokalizować usterkę w programie. Warto w tym celu przeczytać uważnie program, wiersz po wierszu - może w ten sposób uda się wykryć błąd. Czasem jednak to nie pomaga. Możemy wtedy próbować znaleźć usterkę, wypisując dodatkowe informacje w trakcie działania programu.
+W części technicznej kontynuujemy temat radzenia sobie z błędnymi odpowiedziami naszych programów. Tym razem założymy, że wiemy, dla jakich danych wejściowych program nie działa, i musimy zlokalizować usterkę w programie. Warto w tym celu przeczytać uważnie program, wiersz po wierszu – może w ten sposób uda się wykryć błąd. Czasem jednak to nie pomaga. Możemy wtedy próbować znaleźć usterkę, wypisując dodatkowe informacje w trakcie działania programu.
 
 Jako przykład rozważymy nasz wcześniejszy program służący do zliczania cyfr liczby z drobnym błędem:
 
@@ -198,7 +198,7 @@ int main() {
 }
 ```
 
-Jeśli uruchomimy ten program i podalimy na wejściu liczbę 1234, uzyskamy wynik:
+Jeśli uruchomimy ten program i podamy na wejściu liczbę 1234, uzyskamy wynik:
 
 ```
 1999525998
@@ -273,7 +273,7 @@ Oto wynik działania tego programu:
 1999525998
 ```
 
-Przed pętlą `while` nic się z tą zmienną nie dzieje. Wiemy już, czego nie zrobiliśmy - nie przypisaliśmy zmiennej $liczba\_cyfr$ początkowej wartości 0. Zmienna, której nie przypisaliśmy żadnej wartości i której wartości nie wczytaliśmy od użytkownika, może mieć w programie zupełnie dowolną wartość (w zakresie typu zmiennej). Co więcej, wartość ta może być różna, gdy uruchamiamy program na różnych komputerach, a nawet przy kolejnych uruchomieniach programu na tym samym komputerze! Czasem można mieć nawet takie "szczęście", że program zadziała poprawnie na naszym komputerze (gdyż zmienna będzie miała akurat wartość 0), ale wysłany np. do serwisu **Szkopuł** będzie działał błędnie. Jest to dość często popełniany błąd, nazywany popularnie _niezainicjowaniem_ lub _niewyzerowaniem_ zmiennej.
+Przed pętlą `while` nic się z tą zmienną nie dzieje. Wiemy już, czego nie zrobiliśmy – nie przypisaliśmy zmiennej $liczba\_cyfr$ początkowej wartości 0. Zmienna, której nie przypisaliśmy żadnej wartości i której wartości nie wczytaliśmy od użytkownika, może mieć w programie zupełnie dowolną wartość (w zakresie typu zmiennej). Co więcej, wartość ta może być różna, gdy uruchamiamy program na różnych komputerach, a nawet przy kolejnych uruchomieniach programu na tym samym komputerze! Czasem można mieć nawet takie "szczęście", że program zadziała poprawnie na naszym komputerze (gdyż zmienna będzie miała akurat wartość 0), ale wysłany np. do serwisu **Szkopuł** będzie działał błędnie. Jest to dość często popełniany błąd, nazywany popularnie _niezainicjowaniem_ lub _niewyzerowaniem_ zmiennej.
 
 I jeszcze druga błędna wersja naszego programu:
 

--- a/docs/A-podstawy-programowania/A7-for-tablice.md
+++ b/docs/A-podstawy-programowania/A7-for-tablice.md
@@ -4,7 +4,7 @@
 
 ## Prosta pętla for
 
-Wiemy już, że pętle pozwalają nam wielokrotnie wykonywać takie same lub podobne czynności. Jednym z najprostszych przypadków jest sytuacja, gdy chcemy powtórzyć daną czynność i wiemy dokładnie, ile razy chcemy to zrobić. Można do tego celu użyć poznanej już pętli `while`. Jednak lepiej nadaje się do tego pętla `for`. 
+Wiemy już, że pętle pozwalają nam wielokrotnie wykonywać takie same lub podobne czynności. Jednym z najprostszych przypadków jest sytuacja, gdy chcemy powtórzyć daną czynność i wiemy dokładnie, ile razy chcemy to zrobić. Można do tego celu użyć poznanej już pętli `while`. Jednak lepiej nadaje się do tego pętla `for`.
 
 W najprostszej postaci pętla `for` w języku C++ wygląda tak:
 
@@ -84,7 +84,7 @@ int A[4];
 deklaruje tablicę o nazwie ``A``, w której będą przechowywane 4 liczby całkowite. W praktyce jest to zadeklarowanie $4$ zmiennych, które będą nazywać się ``A[0]``, ``A[1]``, ``A[2]`` oraz ``A[3]``. Możemy od tej pory używać każdej z nich oddzielnie, tak jak dotychczas korzystaliśmy ze zmiennych:
 
 ```cpp
-cin >> A[0];	
+cin >> A[0];
 cin >> A[1]; // do zmiennych A[0] i A[1] wczytujemy po jednej liczbie całkowitej
 A[2] = A[0] + A[1];		// teraz A[2] będzie sumą wczytanych liczb
 A[3] = A[0] - A[1];		// zaś A[3] ich różnicą
@@ -98,7 +98,7 @@ int t[n];
 to tablica o nazwie $t$ zawierająca $n$ elementów. Widzimy, że numerujemy je zawsze od zera: $t[0],t[1],\ldots,t[n-1]$.
 
 
-Przypomnijmy sobie nasz poprzedni program, który sumował liczby podane przez użytkownika, i przepiszmy nasz poprzedni program z użyciem tablicy. Zmienna sterująca pętli będzie, jak poprzednio nazywać się $i$, przy czym w $i$-tym okrążeniu chcemy wpisać wartość do $i$-tej komórki tablicy -- innymi słowy, w $i$-tym okrążeniu użyjemy instrukcji ``cin >> t[i]``. Ponieważ elementy tablicy numerujemy od zera, więc zmienna sterująca $i$ będzie tym razem przyjmować wartości $0,1,\ldots,n-1$:
+Przypomnijmy sobie nasz poprzedni program, który sumował liczby podane przez użytkownika, i przepiszmy nasz poprzedni program z użyciem tablicy. Zmienna sterująca pętli będzie, jak poprzednio nazywać się $i$, przy czym w $i$-tym okrążeniu chcemy wpisać wartość do $i$-tej komórki tablicy – innymi słowy, w $i$-tym okrążeniu użyjemy instrukcji ``cin >> t[i]``. Ponieważ elementy tablicy numerujemy od zera, więc zmienna sterująca $i$ będzie tym razem przyjmować wartości $0,1,\ldots,n-1$:
 
 ```cpp
 #include <iostream>
@@ -154,10 +154,10 @@ A zatem pętla `for` działa w następującym cyklu:
 
 ```
 instrukcja_początkowa;
-sprawdź warunek_stopu - jeśli fałszywy, to koniec
+sprawdź warunek_stopu – jeśli fałszywy, to koniec
 instrukcja;
 krok_pętli;
-sprawdź warunek_stopu - jeśli fałszywy, to koniec
+sprawdź warunek_stopu – jeśli fałszywy, to koniec
 instrukcja;
 krok_pętli;
 ...
@@ -195,7 +195,7 @@ Część techniczną rozpoczniemy dosyć nietypowo. Wprowadzimy ciąg liczb, kt�
 
 Pierwsze dwie liczby Fibonacciego to 0 i 1, a każda kolejna liczba jest sumą dwóch poprzednich, np. $8 = 3 + 5$, $34 = 13 + 21$. Zazwyczaj $n$-tą liczbę Fibonacciego oznacza się jako $F_n$ lub $Fib_n$.
 
-Zainteresowanych Czytelników zachęcamy do poszukania w sieci więcej informacji o liczbach Fibonacciego. My tymczasem spróbujemy napisać program, który wyznaczy 50-tą liczbę Fibonacciego (zakładamy, że zerowa liczba Fibonacciego to 0).
+Zainteresowanych Czytelników zachęcamy do poszukania w sieci więcej informacji o liczbach Fibonacciego. My tymczasem spróbujemy napisać program, który wyznaczy 50. liczbę Fibonacciego (zakładamy, że zerowa liczba Fibonacciego to 0).
 
 
 Skorzystajmy z tablicy, w której będziemy przechowywać kolejne liczby Fibonacciego. Piszemy i uruchamiamy poniższy program:
@@ -262,7 +262,7 @@ int main()
 }
 ```
 
-Wyniki programu do pewnego momentu wyglądają rozsądnie, ale gdzieś między 40-tym a 50-tym elementem zaczynają pojawiać się liczby ujemne:
+Wyniki programu do pewnego momentu wyglądają rozsądnie, ale gdzieś między 40. a 50. elementem zaczynają pojawiać się liczby ujemne:
 
 ```
 2 1
@@ -292,7 +292,7 @@ Wyniki programu do pewnego momentu wyglądają rozsądnie, ale gdzieś między 4
 -298632863
 ```
 
-Zauważmy, że 46-ta liczba Fibonacciego jest równa prawie $2 \cdot 10^9$, czyli ledwie mieści się w zakresie typu `int`. Kolejne liczby po prostu wychodzą już poza zakres, co objawia się ujemnymi (oraz bezsensownymi dodatnimi) wartościami. W tym przypadku wystarczy zmienić typ elementów tablicy na jakiś 64-bitowy, np. `long long`:
+Zauważmy, że 46. liczba Fibonacciego jest równa prawie $2 \cdot 10^9$, czyli ledwie mieści się w zakresie typu `int`. Kolejne liczby po prostu wychodzą już poza zakres, co objawia się ujemnymi (oraz bezsensownymi dodatnimi) wartościami. W tym przypadku wystarczy zmienić typ elementów tablicy na jakiś 64-bitowy, np. `long long`:
 
 ```cpp
 #include <iostream>
@@ -312,7 +312,7 @@ int main()
 }
 ```
 
-Dzięki temu już wiemy, jaka jest 50-ta liczba Fibonacciego:
+Dzięki temu już wiemy, jaka jest 50. liczba Fibonacciego:
 
 ```
 ...

--- a/docs/A-podstawy-programowania/A8-funkcje.md
+++ b/docs/A-podstawy-programowania/A8-funkcje.md
@@ -265,7 +265,7 @@ Struktur można używać do przechowywania kilku połączonych informacji w jedn
 #include <algorithm>
 ```
 
-Aby użyć funkcji `abs`, obliczającą wartość bezwzględną z liczby, trzeba przy początku programu umieścić:
+Aby użyć funkcji `abs`, obliczającej wartość bezwzględną z liczby, trzeba przy początku programu umieścić:
 
 ```cpp
 #include <cstdlib>

--- a/docs/A-podstawy-programowania/A8-funkcje.md
+++ b/docs/A-podstawy-programowania/A8-funkcje.md
@@ -39,7 +39,7 @@ cout << endl;
 
 ```
 
-Nie jest to jednak najszczęśliwszy pomysł: taki kod wydłuża się, jest mało czytelny, trudno się w nim szuka błędów, a na domiar pojawia się jeszcze dodatkowy problem z użyciem metody kopiuj-wklej – powielanie pomyłek. W powyższym kodzie brakuje średnika po ``cout << " ***"``, a ten błąd skopiował się trzy razy. Im więcej w kodzie kopiowania, tym bardziej poprawianie błędów będzie żmudne. Dlatego ważną zasadą jest, żeby **unikać kopiowania i powtarzania kodu**. Na szczęście języki programowania dają szeroki wachlarz możliwości radzenia sobie z tym problemem – czasem można zamiast powtórzenia użyć odpowiedniej pętli, tym razem jednak wygodniejsza będzie inna podstawowa konstrukcja: **funkcja**. Funkcja to – w dużym uproszczeniu – fragment kodu, który zapisujemy "na boku" i możemy wywoływać wielokrotnie wewnątrz programu. 
+Nie jest to jednak najszczęśliwszy pomysł: taki kod wydłuża się, jest mało czytelny, trudno się w nim szuka błędów, a na domiar pojawia się jeszcze dodatkowy problem z użyciem metody kopiuj-wklej – powielanie pomyłek. W powyższym kodzie brakuje średnika po ``cout << " ***"``, a ten błąd skopiował się trzy razy. Im więcej w kodzie kopiowania, tym bardziej poprawianie błędów będzie żmudne. Dlatego ważną zasadą jest, żeby **unikać kopiowania i powtarzania kodu**. Na szczęście języki programowania dają wiele możliwości radzenia sobie z tym problemem – czasem można, zamiast powtórzenia użyć odpowiedniej pętli, tym razem jednak wygodniejsza będzie inna podstawowa konstrukcja: **funkcja**. Funkcja to – w dużym uproszczeniu – fragment kodu, który zapisujemy "na boku" i możemy wywoływać wielokrotnie wewnątrz programu.
 
 ## Funkcje i ich argumenty
 
@@ -134,7 +134,7 @@ int min(int a, int b) {
 }
 ```
 
-Powyższa funkcja o nazwie _min_ przyjmuje dwa parametry, $a$ i $b$, oba typu `int`. Wynikiem funkcji jest również liczba typu `int`. Zaznaczymy tutaj, że obszar między nawiasami klamrowymi nazywamy **wnętrzem** albo **ciałem** funkcji. Fragment programu występujący we wnętrzu powyższej funkcji widzieliśmy już wielokrotnie, jest to rzeczywiście obliczanie minimum z dwóch liczb. Jak pamiętamy, wynik funkcji opatrzony jest słowem kluczowym `return`. Jeśli $a<b$, to wynikiem funkcji jest $a$, a w przeciwnym razie $b$. 
+Powyższa funkcja o nazwie _min_ przyjmuje dwa parametry, $a$ i $b$, oba typu `int`. Wynikiem funkcji jest również liczba typu `int`. Zaznaczymy tutaj, że obszar między nawiasami klamrowymi nazywamy **wnętrzem** albo **ciałem** funkcji. Fragment programu występujący we wnętrzu powyższej funkcji widzieliśmy już wielokrotnie, jest to rzeczywiście obliczanie minimum z dwóch liczb. Jak pamiętamy, wynik funkcji opatrzony jest słowem kluczowym `return`. Jeśli $a<b$, to wynikiem funkcji jest $a$, a w przeciwnym razie $b$.
 
 Jeśli zamiast wartości w parametrach funkcji umieścimy jakieś wyrażenia, funkcja również wykona się, ale najpierw obliczy wartości tych wyrażeń. Przykładowo w tym fragmencie programu:
 
@@ -265,7 +265,7 @@ Struktur można używać do przechowywania kilku połączonych informacji w jedn
 #include <algorithm>
 ```
 
-Aby użyć funkcji `abs`, obliczającej wartość bezwzględną z liczby, trzeba przy początku programu umieścić:
+Aby użyć funkcji `abs`, obliczającą wartość bezwzględną z liczby, trzeba przy początku programu umieścić:
 
 ```cpp
 #include <cstdlib>
@@ -352,7 +352,7 @@ int main() {
 
 # Część techniczna: C++ czy ++C, czyli sztuczki programistyczne
 
-W tej części technicznej opiszemy zagadnienie, którego znajomość nie jest konieczna przy pisaniu programów, jednak poszerza naszą wiedzę o języku C++. W odróżnieniu od poprzedniej części lekcji, potraktuj je jako ciekawostkę bardziej niż konieczną wiedzę.
+W tej części technicznej opiszemy zagadnienie, którego znajomość nie jest konieczna przy pisaniu programów, jednak poszerza naszą wiedzę o języku C++. W odróżnieniu od poprzedniej części lekcji potraktuj je jako ciekawostkę bardziej niż konieczną wiedzę.
 
 W większości pętli, które dotychczas pisaliśmy, pojawiały się instrukcje `i++` lub `i--`. W języku C++ dostępne są także instrukcje `++i` oraz `--i`. Czym one się różnią od tych wcześniejszych?
 
@@ -365,7 +365,7 @@ a = b = c = 1;
 
 wszystkie trzy zmienne uzyskują wartość $1$. Działa to tak, że najpierw zmiennej $c$ przypisujemy wartość 1. Wynikiem przypisania $c=1$ jest prawa strona, czyli $1$, i w przypisaniu $b=(c=1)$ zmienna $b$ uzyskuje wartość $1$ (w powyższym wyrażeniu mogliśmy pominąć nawiasy). Na końcu to samo dzieje się ze zmienną $a$.
 
-Tak samo jak zwykłe przypisanie, również przypisania skrócone zwracają pewną wartość. Jaka to wartość? Otóż taka sama, jak gdyby zamiast przypisania skróconego wpisać równoważne mu pełne przypisanie. Poniższy program:
+Tak samo, jak zwykłe przypisanie, również przypisania skrócone zwracają pewną wartość. Jaka to wartość? Otóż taka sama, jak gdyby zamiast przypisania skróconego wpisać równoważne mu pełne przypisanie. Poniższy program:
 
 ```cpp
 int a, b;

--- a/docs/B-proste-algorytmy/B1-podtablice.md
+++ b/docs/B-proste-algorytmy/B1-podtablice.md
@@ -78,7 +78,7 @@ int main() {
 
 ## Ciąg identycznych/rosnących/malejących elementów
 
-W kolejnym zadaniu znowu dana jest tablica, ale tym razem naszym celem jest znalezienie najdłuższego fragmentu, w którym wszystkie elementy są takie same. Jako odpowiedź musimy podać długość tego fragmentu --  na przykład dla ciągu $(4, 4, 9, 2, 2, 6, 10, 7, 7, 7, 7, 1, 2, 2, 2, 5)$ odpowiedzią jest $4$, jako że element $7$ występuje właśnie $4$ razy z rzędu.
+W kolejnym zadaniu znowu dana jest tablica, ale tym razem naszym celem jest znalezienie najdłuższego fragmentu, w którym wszystkie elementy są takie same. Jako odpowiedź musimy podać długość tego fragmentu – na przykład dla ciągu $(4, 4, 9, 2, 2, 6, 10, 7, 7, 7, 7, 1, 2, 2, 2, 5)$ odpowiedzią jest $4$, jako że element $7$ występuje właśnie $4$ razy z rzędu.
 
 Użyjemy bardzo podobnego pomysłu, co w poprzednim zadaniu, z przejściem pętlą przez wszystkie elementy. Zamiast jednej dodatkowej zmiennej potrzebujemy tym razem jednak co najmniej dwóch. Pierwsza (`najwiecej`) będzie przechowywać (jak poprzednio) informację o najlepszym napotkanym dotychczas kandydacie. Druga (`ostatnie`) musi na bieżąco pamiętać, ile razy widzieliśmy ostatni napotkany element:
 

--- a/docs/B-proste-algorytmy/B2-wyszukiwanie-binarne.md
+++ b/docs/B-proste-algorytmy/B2-wyszukiwanie-binarne.md
@@ -2,7 +2,7 @@
 
 ## "Za dużo, za mało"
 
-W dość dawnych czasach pewna stacja radiowa organizowała dla słuchaczy zabawę: przygotowywano pewną sumę pieniędzy do wygrania, na antenie ogłaszano jej orientacyjną wielkość (na przykład "do 20 000 zł"), a następnie słuchacze dzwonili do studia. Pierwsza osoba, która podała dokładną sumę ("dwanaście tysięcy sześcset dwadzieścia trzy złote i pięćdziesiąt siedem groszy"), wygrywała ją na własność. Po każdym telefonie słuchacza rozlegał się komunikat "ZA DUŻO", jeśli podana została zbyt wielka suma, lub "ZA MAŁO", jeśli zbyt skromna.
+W dość dawnych czasach pewna stacja radiowa organizowała dla słuchaczy zabawę: przygotowywano pewną sumę pieniędzy do wygrania, na antenie ogłaszano jej orientacyjną wielkość (na przykład "do 20 000 zł"), a następnie słuchacze dzwonili do studia. Pierwsza osoba, która podała dokładną sumę ("dwanaście tysięcy sześćset dwadzieścia trzy złote i pięćdziesiąt siedem groszy"), wygrywała ją na własność. Po każdym telefonie słuchacza rozlegał się komunikat "ZA DUŻO", jeśli podana została zbyt wielka suma, lub "ZA MAŁO", jeśli zbyt skromna.
 
 Załóżmy, że jesteśmy jedynym dzwoniącym do studia, a suma do rozdania to całkowita liczba między 1 a 1000 złotych. Ile telefonów potrzebujemy, aby zgadnąć właściwą liczbę?
 
@@ -27,7 +27,7 @@ Strategię tę można powtórzyć: jeśli wynik mieści się w przedziale [501,1
 | 599    | ZA MAŁO  | Kwota w przedziale [600,600]  |
 | 600    | WYGRANA! |                               |
 
-Do właściwej kwoty doszliśmy w dziesięciu telefonach. Przy kwocie 625 zł zgadlibyśmy już w trzeciej próbie. A czy jest możliwe, że wykonalibyśmy dużo więcej pracy? Nie jest! Popatrzmy na przedziały napisane w ostatniej kolumnie. Pierwszy z nich ma długość 500, drugi 249, kolejny 124... każdy następny jest około dwa razy krótszy od poprzedniego i jest tak bez względu na to, jakie otrzymywaliśmy odpowiedzi. Cokolwiek by się zatem nie działo, najpóźniej w dziesiątym kroku długość tego przedziału spadnie do 1, a więc będziemy znali właściwą liczbę.
+Do właściwej kwoty doszliśmy w dziesięciu telefonach. Przy kwocie 625 zł zgadlibyśmy już w trzeciej próbie. A czy jest możliwe, że wykonalibyśmy dużo więcej pracy? Nie jest! Popatrzmy na przedziały napisane w ostatniej kolumnie. Pierwszy z nich ma długość 500, drugi 249, kolejny 124... każdy następny jest około dwukrotnie krótszy od poprzedniego i jest tak bez względu na to, jakie otrzymywaliśmy odpowiedzi. Cokolwiek by się zatem nie działo, najpóźniej w dziesiątym kroku długość tego przedziału spadnie do 1, a więc będziemy znali właściwą liczbę.
 
 Algorytm, który szuka zadanej wielkości tą metodą – dzielenia na pół przedziału, w którym może się znajdować – zwany jest **wyszukiwaniem binarnym**.
 
@@ -47,7 +47,7 @@ Ciąg przechowujemy w tablicy `tablica[]`, indeksowanej od $0$ do $n-1$.
 Naszym zadaniem jest znaleźć pozycję (indeks tablicy), na którym jest liczba $12$ – załóżmy na chwilę, że mamy pewność, iż liczba w tablicy na pewno się znajduje. Najprostszym sposobem byłoby sprawdzenie wszystkich elementów tablicy za pomocą prostej pętli.
 Jak zrobić to tak, aby nie napracować się za bardzo? Identycznie jak w radiowej grze: sprawdźmy najpierw, jaka liczba jest w połowie tablicy (czyli w komórce `tablica[7]`). W tym wypadku – $21$, czyli za dużo, a to znaczy, że $12$ na pewno znajduje się pomiędzy `tablica[0]` a `tablica[6]`. Wystarczy teraz powtórzyć operację na mniejszym, początkowym fragmencie tablicy – od indeksu $0$ do $6$. W tym celu sprawdzamy środek tego fragmentu, czyli wartość `tablica[3]`...
 
-Bardziej formalnie: staramy się znaleźć pewną liczbę `x` w tablicy `tablica[0..n-1]`, czyli podać taki indeks `i`, dla którego `tablica[i] = x`. W tym celu weźmy dwie zmienne `początek` i `koniec`, ustawmy `początek` na $0$ i `koniec` na $n-1$. Będziemy starać się utrzymywać następujący fakt: element `x` znajduje się w tablicy pomiędzy indeksami `początek` i `koniec`. Patrzymy, co znajduje się dokładnie na środku pomiędzy tymi indeksami (czyli definiujemy zmienną  `środek` jako średnią `początek` i `koniec`) – jeśli w komórce `tablica[środek]` jest liczba większa od  `x`, wiemy że trzeba szukać dalej pomiędzy  `początek` a  `środek`. Jeśli zaś mniejsza od  `x`, szukamy między  `środek` a  `koniec`:
+Bardziej formalnie: staramy się znaleźć pewną liczbę `x` w tablicy `tablica[0..n-1]`, czyli podać taki indeks `i`, dla którego `tablica[i] = x`. W tym celu weźmy dwie zmienne `początek` i `koniec`, ustawmy `początek` na $0$ i `koniec` na $n-1$. Będziemy starać się utrzymywać następujący fakt: element `x` znajduje się w tablicy pomiędzy indeksami `początek` i `koniec`. Patrzymy, co znajduje się dokładnie na środku pomiędzy tymi indeksami (czyli definiujemy zmienną `środek` jako średnią `początek` i `koniec`) – jeśli w komórce `tablica[środek]` jest liczba większa od `x` wiemy, że trzeba szukać dalej pomiędzy `początek` a `środek`. Jeśli zaś mniejsza od  `x`, szukamy między `środek` a `koniec`:
 
 ```cpp
 int poczatek = 0;
@@ -101,7 +101,8 @@ Widzimy (i bardzo łatwo jest pokazać), że dla $n=2^k$ wykonamy dokładnie $k$
 Taka liczba $k$ zwana jest **logarytmem dwójkowym** z liczby $n$.
 
 Definiując precyzyjnie, logarytm dwójkowy z dowolnej liczby dodatniej $a$ to taka liczba $x$,
-dla której $2^x=a$. Oznaczamy ją przez $\log_2 a$, przy czym często piszemy po prostu $\log a$.
+dla której $2^x=a$. Taką liczbę oznaczamy przez $\log_2 a$, gdzie 2 nazywamy *podstawą logarytmu*.
+W informatyce, gdy pomijamy podstawę (pisząc $\log a$) chodzi nam właśnie o logarytm dwójkowy.
 Dla "większości" możliwych argumentów $a$, nawet całkowitych, liczba $\log a$ nie jest całkowita,
 a nawet wymierna (na przykład $\log 12 = 3,5849\ldots$).
 Nam będzie na ogół przydatne jej zaokrąglenie do liczby całkowitej – w szczególności,
@@ -166,7 +167,7 @@ while (poczatek < koniec) {
 }
 ```
 
-Teraz  `środek` może być równy  `koniec`, ale nigdy nie będzie równy `początek`. Algorytm nie może się zatem zapętlić.
+Teraz `środek` może być równy `koniec`, ale nigdy nie będzie równy `początek`. Algorytm nie może się zatem zapętlić.
 
 ## Zadania
 

--- a/docs/B-proste-algorytmy/B3-zlozonosc-1.md
+++ b/docs/B-proste-algorytmy/B3-zlozonosc-1.md
@@ -28,7 +28,7 @@ for (int i = 0; i < n; i++) {
 cout << licznik << "\n";
 ```
 
-Jeśli zastanowimy się trochę bardziej zauważymy, że wykonujemy tu bardzo dużo niepotrzebnych obliczeń. Na przykład liczymy sumę `A[1] + A[2] + A[3]`, a chwilę później `A[1] + A[2] + A[3] + A[4]`, sumując ją od nowa. Zróbmy zatem inaczej: ustalmy sobie na chwilę wartość $i$, dla której policzymy sumy `A[i]`, `A[i] + A[i + 1]`, `A[i] + A[i + 1] + A[i + 2]`, każdą następną licząc na podstawie poprzedniej:
+Jeśli zastanowimy się trochę bardziej, zauważymy że wykonujemy tu bardzo dużo niepotrzebnych obliczeń. Na przykład liczymy sumę `A[1] + A[2] + A[3]`, a chwilę później `A[1] + A[2] + A[3] + A[4]`, sumując ją od nowa. Zróbmy zatem inaczej: ustalmy sobie na chwilę wartość $i$, dla której policzymy sumy `A[i]`, `A[i] + A[i + 1]`, `A[i] + A[i + 1] + A[i + 2]`, każdą następną licząc na podstawie poprzedniej:
 
 ```cpp
 int licznik = 0; // Tu będziemy zliczać fragmenty o sumie K.
@@ -48,7 +48,7 @@ for (int i = 0; i < n; i++) { // Dla ustalonego i:
 cout << licznik << "\n";
 ```
 
-Jaka jest w praktyce różnica między tymi dwoma algorytmami? Na potrzeby kursu użyjemy do ich przetestowania poleceń systemu Linux -- powiemy o nich więcej w jednym z kolejnych rozdziałów. Na razie wystarczy wiedzieć tylko, że pliki `100.in`, `1000.in` i `5000.in` zawierają odpowiednio 100, 1000 i 5000 liczb całkowitych, zaś poniższe polecenia uruchamiają nasze algorytmy (pod nazwami `program1` i `program2`) na danych z tych plików, oraz mierzą czas potrzebny na działanie programów.
+Jaka jest w praktyce różnica między tymi dwoma algorytmami? Na potrzeby kursu użyjemy do ich przetestowania poleceń systemu Linux – powiemy o nich więcej w jednym z kolejnych rozdziałów. Na razie wystarczy wiedzieć tylko, że pliki `100.in`, `1000.in` i `5000.in` zawierają odpowiednio 100, 1000 i 5000 liczb całkowitych, zaś poniższe polecenia uruchamiają nasze algorytmy (pod nazwami `program1` i `program2`) na danych z tych plików, oraz mierzą czas potrzebny na działanie programów.
 
 Sprawdźmy zatem ich działanie najpierw dla tablicy 100 liczb:
 
@@ -109,17 +109,17 @@ Szybszy program działa w 0.05s, wolniejszy – minutę i 18 sekund. Dla 20000 l
 
 Widzimy, że pierwszy program działa nie tylko wolniej, ale też różnica ta pogłębia się coraz bardziej w miarę, jak rosną dane wejściowe do algorytmu. Aby sformalizować tę obserwację, należałoby policzyć, ile instrukcji wykonają oba programy i porównać wyniki. To jednak okazuje się bardziej skomplikowane, niż wydaje się na pierwszy rzut oka. Po pierwsze – których instrukcji? Czy chcemy liczyć linijki kodu, czy pojedyncze operacje arytmetyczne? Nawet tutaj są różnice, bo np. dodawanie wykonuje się na ogół znacznie szybciej niż dzielenie. A może chcemy zejść na bardziej podstawowy poziom i analizować, co jest pojedynczą instrukcją dla mechanizmów wewnątrz komputera (tzw. instrukcje procesora)? Wydaje się to ,,sprawiedliwe'', ale niestety zależy od języka programowania, architektury samego komputera i innych rzeczy, którymi w kontekście algorytmu zwykle nie chcemy się zajmować.
 
-Typowe ,,kompromisowe'' rozwiązanie to wybranie jednego rodzaju operacji, najważniejszej dla programu i skupieniu się tylko na niej -- można wybrać na przykład operacje arytmetyczne (dodawanie, odejmowanie, mnożenie, dzielenie) albo tylko iteracje pętli. Oczywiście aby ten wynik miał sens, trzeba wybrać taką instrukcję, która w programie występuje najczęściej. W naszych przykładach dobrym wyborem jest na przykład instrukcja dodawania (`suma += A[j]`).
+Typowe ,,kompromisowe'' rozwiązanie to wybranie jednego rodzaju operacji, najważniejszej dla programu i skupieniu się tylko na niej – można wybrać na przykład operacje arytmetyczne (dodawanie, odejmowanie, mnożenie, dzielenie) albo tylko iteracje pętli. Oczywiście, aby ten wynik miał sens, trzeba wybrać taką instrukcję, która w programie występuje najczęściej. W naszych przykładach dobrym wyborem jest na przykład instrukcja dodawania (`suma += A[j]`).
 
-Druga ważna kwestia przy liczeniu instrukcji to dane wejściowe. W zasadzie każdy algorytm dla jednych danych będzie działał bardziej efektywnie niż dla innych -- z reguły dla mniejszych działa szybciej, dla większych wolniej. Dobrym wyjściem jest skupienie się na konkretnym *rozmiarze* danych, czyli w naszym wypadku na wielkości wejściowej tablicy, którą oznaczamy przez $n$. Policzmy zatem dla przykładu liczbę instrukcji dodawania (ignorując wszystkie pozostałe) w drugim z naszych programów, na początek dla tablicy mającej $5$ elementów, czyli $n = 5$:
+Druga ważna kwestia przy liczeniu instrukcji to dane wejściowe. W zasadzie każdy algorytm dla jednych danych będzie działał bardziej efektywnie niż dla innych – z reguły dla mniejszych działa szybciej, dla większych wolniej. Dobrym wyjściem jest skupienie się na konkretnym *rozmiarze* danych, czyli w naszym wypadku na wielkości wejściowej tablicy, którą oznaczamy przez $n$. Policzmy zatem dla przykładu liczbę instrukcji dodawania (ignorując wszystkie pozostałe) w drugim z naszych programów, na początek dla tablicy mającej $5$ elementów, czyli $n = 5$:
 
   * Dla `i = 0` będzie `5` instrukcji dodawania (po jednej dla `j = 0, 1, 2, 3, 4`),
   * Dla `i = 1` będą `4` instrukcje (zmienna `j` przybiera wartości `1, 2, 3, 4`, każda iteracja to znowu jedno dodawanie),
   * Dla `i = 2` będą `3` instrukcje,
   * Dla `i = 3` będą `2` instrukcje,
   * Dla `i = 4` będzie `1` instrukcja.
-  
-Łącznie zatem algorytm wykona $5 + 4 + 3 + 2 + 1 = 15$ instrukcji dodawania. A jaki będzie ,,ogólny'' wynik, dla pewnego $n$? Bardzo podobne rozumowanie prowadzi nas do wyniku 
+
+Łącznie zatem algorytm wykona $5 + 4 + 3 + 2 + 1 = 15$ instrukcji dodawania. A jaki będzie ,,ogólny'' wynik, dla pewnego $n$? Bardzo podobne rozumowanie prowadzi nas do wyniku
 
 \[
   n + n-1 + n-2 + \ldots + 1 = \frac{n(n+1)}{2} = \frac{1}{2}n^2 + \frac{1}{2}n.
@@ -133,7 +133,7 @@ Oszacujmy jeszcze pierwszy (wolniejszy) z naszych algorytmów. Jest to odrobinę
   \frac{(n-1)n(n+1)}{6} = \frac{n^3}{6} - \frac{n}{6}.
 \]
 
-Teraz można powiedzieć, skąd bierze się różnica w działaniu, wstawiając do tych wzorów wartości $n$. Dla $n \approx 1000$ wartości tych wyrażeń to około pół miliona w pierwszym wypadku, i około 160 milionów w drugim. Im większe $n$, tym te różnice stają się bardziej znaczące.
-Przy odpowiednio dużych (a wciąż ,,życiowych'') danych wolniejszy algorytm przestaje mieć praktyczny sens: nawet zatrudnienie do obliczeń bardzo mocnego komputera nie sprawiłoby, że mógłby rywalizować z szybszym algorytmem. Kluczowy tutaj jest wyraz $n^3$ w pierwszym algorytmie i $n^2$ w drugim. Dlatego pierwszy algorytm (i inne, które wykonują około $n^3$ operacji dla danych wielkości $n$) nazywa się **sześciennymi**, a algorytmy wykonujące $n^2$ operacji -- **kwadratowymi**; dlatego też różnica między algorytmem sześciennym i kwadratowym będzie dla nas kluczowa. Z kolei algorytmy takie jak szukanie maksimum/minimum w tablicy (rozdział "Poruszanie się po tablicach"), dla tablicy wielkości $n$ wykonują około $n$ operacji i nazywamy je **liniowymi**.
+Teraz można powiedzieć, skąd bierze się różnica w działaniu, wstawiając do tych wzorów wartości $n$. Dla $n \approx 1000$ wartości tych wyrażeń to około pół miliona w pierwszym wypadku i około 160 milionów w drugim. Im większe $n$, tym te różnice stają się bardziej znaczące.
+Przy odpowiednio dużych (a wciąż ,,życiowych'') danych wolniejszy algorytm przestaje mieć praktyczny sens: nawet zatrudnienie do obliczeń bardzo mocnego komputera nie sprawiłoby, że mógłby rywalizować z szybszym algorytmem. Kluczowy tutaj jest wyraz $n^3$ w pierwszym algorytmie i $n^2$ w drugim. Dlatego pierwszy algorytm (i inne, które wykonują około $n^3$ operacji dla danych wielkości $n$) nazywa się **sześciennymi**, a algorytmy wykonujące $n^2$ operacji – **kwadratowymi**; dlatego też różnica między algorytmem sześciennym i kwadratowym będzie dla nas kluczowa. Z kolei algorytmy takie jak szukanie maksimum/minimum w tablicy (rozdział "Poruszanie się po tablicach"), dla tablicy wielkości $n$ wykonują około $n$ operacji i nazywamy je **liniowymi**.
 
 

--- a/docs/B-proste-algorytmy/B4-systemy-pozycyjne.md
+++ b/docs/B-proste-algorytmy/B4-systemy-pozycyjne.md
@@ -2,11 +2,11 @@
 
 ## Skąd wziął się system dziesiętny
 
-Ludzkość długo doskonaliła umiejętność zapisywania liczb. Dopiero w późnym średniowieczu Europa odeszła od zapisu ,,odziedziczonego'' po Imperium Rzymskim, do dziś zwanego *liczbami rzymskimi*. W tym systemie litera `I` oznaczała 1, `V` to 5, a litery `X`, `L`, `C`, `D` i `M` odpowiadały kolejno wartościom 10, 50, 100, 500 i 1000 − na przykład 73 to `LXXIII`. Dodatkowo, by zapisać 4, zamiast `IIII` używa się `IV`. Liczba 9 to `IX`, 40 to `XL` i tak dalej. 12
+Ludzkość długo doskonaliła umiejętność zapisywania liczb. Dopiero w późnym średniowieczu Europa odeszła od zapisu ,,odziedziczonego'' po Imperium Rzymskim, do dziś zwanego *liczbami rzymskimi*. W tym systemie litera `I` oznaczała 1, `V` to 5, a litery `X`, `L`, `C`, `D` i `M` odpowiadały kolejno wartościom 10, 50, 100, 500 i 1000 − na przykład 73 to `LXXIII`. Co więcej, by zapisać 4, zamiast `IIII` używa się `IV`. Liczba 9 to `IX`, 40 to `XL` i tak dalej. 12
 
 Czemu odeszliśmy od zapisu rzymskiego? Nie jest trudny do opanowania, ale problemy zaczynają się przy liczbach większych niż 3000 − sami Rzymianie nie byli konsekwentni i mieli kilka różnych metod na większe liczby. Kłopot leży między innymi w tym, że dla każdej ,,nowej'' liczby (5000, 10000, 50000, ...) trzeba użyć nowej litery. Na Olimpiadzie Informatycznej, w której często trzeba wczytywać i wypisywać nawet dziewięciocyfrowe liczby (np. 267 142 129) litery szybko by się skończyły.
 
-Jeszcze większy problem pojawia się, jeśli trzeba często dodawać wiele liczb (*kto nie wierzy, niech spróbuje szybko odpowiedzieć na pytanie, ile to jest XCVII+CLXIX*). To prawdopodobnie względy praktyczne, takie jak księgi rachunkowe i rejestry kupieckie, wymusiły w końcu odejście od systemu rzymskiego. Nowy sposób zapisu został wynaleziony w Indiach, a do Europy dostał się za sprawą Arabów, którzy w średniowieczu panowali m.in. na Półwyspie Iberyjskim − stąd nazwa *cyfry arabskie*. Jak wiemy, w tym zapisie mamy dziesięć cyfr (0, 1, 2, 3, 4, 5, 6, 7, 8, 9), a wartość cyfry zależy od pozycji na której stoi: w liczbie 273 cyfra 3 oznacza jedności (czyli $3 \cdot 1$, cyfra 7 to dziesiątki ($7 \cdot 10$), a 2 to setki ($2 \cdot 100$). Taki system nazywa się *pozycyjnym*.
+Jeszcze większy problem pojawia się, jeśli trzeba często dodawać wiele liczb (*kto nie wierzy, niech spróbuje szybko odpowiedzieć na pytanie, ile to jest XCVII+CLXIX*). To prawdopodobnie względy praktyczne, takie jak księgi rachunkowe i rejestry kupieckie, wymusiły w końcu odejście od systemu rzymskiego. Nowy sposób zapisu został wynaleziony w Indiach, a do Europy dostał się za sprawą Arabów, którzy w średniowieczu panowali m.in. na Półwyspie Iberyjskim − stąd nazwa *cyfry arabskie*. Jak wiemy, w tym zapisie mamy dziesięć cyfr (0, 1, 2, 3, 4, 5, 6, 7, 8, 9), a wartość cyfry zależy od pozycji, na której stoi: w liczbie 273 cyfra 3 oznacza jedności (czyli $3 \cdot 1$, cyfra 7 to dziesiątki ($7 \cdot 10$), a 2 to setki ($2 \cdot 100$). Taki system nazywa się *pozycyjnym*.
 
 ## Nie-dziesiętne systemy pozycyjne
 
@@ -42,7 +42,7 @@ Należy jednak pamiętać, że wynik może być nieokreślony (np. jeśli ktoś 
 
 czyli wynik wychodzący poza zakres. Objawia się to bitem na pozycji 8 równym 1.
 
-Komputer najczęściej radzi sobie z takimi sytuacjami po prostu tracąc bity, które nie zmieszczą się w zakresie – czyli wynikiem powyższego działania w typie jednobajtowym byłoby po prostu $10_2 = 2$. Odpowiada to obliczeniu reszty z dzielenia wyniku przez $2^8$, a ogólniej przez $2^k$, gdzie $k$ jest liczbą bitów, które mamy do dyspozycji.
+Komputer najczęściej radzi sobie z takimi sytuacjami, po prostu tracąc bity, które nie zmieszczą się w zakresie – czyli wynikiem powyższego działania w typie jednobajtowym byłoby po prostu $10_2 = 2$. Odpowiada to obliczeniu reszty z dzielenia wyniku przez $2^8$, a ogólniej przez $2^k$, gdzie $k$ jest liczbą bitów, które mamy do dyspozycji.
 
 ## Reprezentacja liczb ujemnych
 
@@ -81,7 +81,7 @@ Dlaczego chcemy używać systemu szesnastkowego? Odpowiedź jest w poprzednim ro
 
 ## Zamiana między systemami
 
-Załóżmy, że chcemy przeliczyć liczbę zapisaną w systemie ósemkowym na system dziesiętny. Innymi słowy, dla liczby zapisanej ósemkowo za pomocą cyfr $c_{k-1} c_{k-2} \ldots c_1 c_0$ (gdzie $c_0$ to cyfra jedności, a cyfra $c_{k-1}$ jest najbardziej znacząca) chcemy obliczyć jej wartość. Na potrzeby tego kursu załóżmy, że obliczona wartość mieści się w zakresie typu którego chcemy użyć (np. `int` w C++). Jak już wiemy, w systemie ósemkowym wartość takiej liczby jest równa:
+Załóżmy, że chcemy przeliczyć liczbę zapisaną w systemie ósemkowym na system dziesiętny. Innymi słowy, dla liczby zapisanej ósemkowo za pomocą cyfr $c_{k-1} c_{k-2} \ldots c_1 c_0$ (gdzie $c_0$ to cyfra jedności, a cyfra $c_{k-1}$ jest najbardziej znacząca) chcemy obliczyć jej wartość. Na potrzeby tego kursu załóżmy, że obliczona wartość mieści się w zakresie typu, którego chcemy użyć (np. `int` w C++). Jak już wiemy, w systemie ósemkowym wartość takiej liczby jest równa:
 
 $c_0 + c_1 \cdot 8 + c_2 \cdot 8^2 + \ldots + c_{k-1} 8^{k-1}$
 
@@ -94,7 +94,7 @@ Na przykład $1452_8 = 2 + 8 \cdot (5 + 8 \cdot (4 + 8 \cdot 1)) = 810_{10}$. Za
 ```cpp
 // Pominiemy wczytywanie danych i inne chwilowo nieistotne fragmenty.
 
-vector<int> C(k); 
+vector<int> C(k);
 
 // Zmienna k to długość liczby ósemkowej .
 // Wektor C zawiera kolejne cyfry - C[0] to cyfra jedności, C[1] to cyfra "ósemek", i tak dalej.
@@ -111,14 +111,14 @@ cout << wynik << "\n";
 
 Ten algorytm nazywa się czasem *schematem Hornera* (chociaż należy uważać: ta sama nazwa używana jest też w innych kontekstach). Bez trudu można go zmodyfikować tak, aby przeliczał z systemu piątkowego, siódemkowego lub o innej podstawie $a$: wystarczy wpisać $a$ w miejsce $8$ w powyższym kodzie. Zwróćmy też uwagę na fakt, że w zmiennej `wynik` tak naprawdę znajdują się wartości dla ,,kawałków'' naszej liczby: na przykład wywołany dla liczby $1452_8$ algorytm w pierwszym kroku przypisuje `wynik = 1` (czyli $1_8$) w drugim $1 \cdot 8 + 4 = 12$, czyli $14_8$, w trzecim $12 \cdot 8 + 5 = 101$, czyli $145_8$, w czwartym − $101 \cdot 8 + 2 = 810_{10}$, czyli $1452_8$. Dopisanie kolejnej cyfry $c$ do liczby ósemkowej $s$ to po prostu pomnożenie $s$ przez $8$ i dodanie $c$ − podobnie jak w systemie dziesiętnym dopisanie cyfry $c$ na koniec liczby $s$ to pomnożenie jej przez $10$ i dodanie $c$.
 
-Wykorzystamy podobną obserwację, żeby rozwiązać problemem odwrotny: dana jest liczba dziesiętna $s$, a chcemy wyznaczyć jej zapis ósemkowy. Tak jak w zapisie dziesiętnym ostatnia cyfra jest zawsze resztą liczby z dzielenia przez $10$, tak w zapisie ósemkowym ostatnia cyfra będzie zawsze resztą liczby $s$ z dzielenia przez $8$ (w C++ to po prostu `s%8`). Formalnie, dzieje się tak dlatego, że w zapisie ósemkowym wszystkie pozostałe cyfry oznaczają wielokrotności $8$, $8^2$, $8^3$ itd., a zatem tylko ostatnia cyfra może wpływać na resztą z dzielenia. Weźmy dla przykładu liczbę $s = 791_{10}$ -- jej reszta z dzielenia przez $8$ będzie równa $7$, a zatem to będzie ostatnia cyfra w zapisie ósemkowym. 
+Wykorzystamy podobną obserwację, żeby rozwiązać problemem odwrotny: dana jest liczba dziesiętna $s$, a chcemy wyznaczyć jej zapis ósemkowy. Tak jak w zapisie dziesiętnym ostatnia cyfra jest zawsze resztą liczby z dzielenia przez $10$, tak w zapisie ósemkowym ostatnia cyfra będzie zawsze resztą liczby $s$ z dzielenia przez $8$ (w C++ to po prostu `s%8`). Formalnie, dzieje się tak dlatego, że w zapisie ósemkowym wszystkie pozostałe cyfry oznaczają wielokrotności $8$, $8^2$, $8^3$ itd., a zatem tylko ostatnia cyfra może wpływać na resztą z dzielenia. Weźmy dla przykładu liczbę $s = 791_{10}$ – jej reszta z dzielenia przez $8$ będzie równa $7$, a zatem to będzie ostatnia cyfra w zapisie ósemkowym.
 
-Zauważmy teraz, że wynik dzielenia $s/8$ zaokrąglony w dół (czyli w C++ wynik `s/8`) ma taki sam zapis w zapisie ósemkowym jak $s$, tyle że bez ostatniej cyfry. Znowu, identycznie jest w systemie dziesiętnym: skreślenie z liczby ostatniej cyfry to po prostu podzielenie jej przez $10$ z zaokrągleniem w dół. Zatem po wykonaniu dzielenia `s = s/8` możemy łatwo określić przedostatnią cyfrę, jako że będzie to reszta z dzielenia ,,nowej'' liczby $s$ przez $8$. W naszym przykładzie, dla $s = 791$ po wyznaczeniu ostatniej cyfry ($7$) dzielimy $791$ przez $8$, otrzymując $98$. Reszta z dzielenia $98$ przez $8$ to $2$ − to będzie przedostatnia cyfra. Kolejne cyfry wyznaczamy powtarzając ten sam schemat tak długo, aż po wyznaczeniu ostatniej cyfry wartość $s$ spadnie do $0$: $98 / 2 = 12$, więc kolejną cyfrą jest reszta z dzielenia $12$ przez $8$, czyli $4$. Wreszcie $12 / 8 = 1$, i to jest pierwsza cyfra liczby $s = 791$ w zapisie ósemkowym, a cały zapis to $1427$.
+Zauważmy teraz, że wynik dzielenia $s/8$ zaokrąglony w dół (czyli w C++ wynik `s/8`) ma taki sam zapis w zapisie ósemkowym jak $s$, tyle że bez ostatniej cyfry. Znowu, identycznie jest w systemie dziesiętnym: skreślenie z liczby ostatniej cyfry to po prostu podzielenie jej przez $10$ z zaokrągleniem w dół. Zatem po wykonaniu dzielenia `s = s/8` możemy łatwo określić przedostatnią cyfrę, jako że będzie to reszta z dzielenia ,,nowej'' liczby $s$ przez $8$. W naszym przykładzie, dla $s = 791$ po wyznaczeniu ostatniej cyfry ($7$) dzielimy $791$ przez $8$, otrzymując $98$. Reszta z dzielenia $98$ przez $8$ to $2$ − to będzie przedostatnia cyfra. Kolejne cyfry wyznaczamy, powtarzając ten sam schemat tak długo, aż po wyznaczeniu ostatniej cyfry wartość $s$ spadnie do $0$: $98 / 2 = 12$, więc kolejną cyfrą jest reszta z dzielenia $12$ przez $8$, czyli $4$. Wreszcie $12 / 8 = 1$, i to jest pierwsza cyfra liczby $s = 791$ w zapisie ósemkowym, a cały zapis to $1427$.
 
 Podany schemat bardzo łatwo zapisać w postaci pętli. W C++ będzie to wyglądało jak poniżej. Aby poradzić sobie z faktem, że cyfry otrzymujemy od ostatniej do pierwszej, będziemy dodawać je do pomocniczego wektora `L`, który następnie wypiszemy w odwrotnej kolejności.
 
 ```cpp
-int s; 
+int s;
 cin >> s;
 // Liczba s jest tą, którą chcemy zamienić na system ósemkowy.
 

--- a/docs/B-proste-algorytmy/B5-rekurencja.md
+++ b/docs/B-proste-algorytmy/B5-rekurencja.md
@@ -37,21 +37,21 @@ jak na każde "normalne" wywołanie funkcji
 - obliczy jej wartość wykonując ją wiersz po wierszu,
 - mając obliczoną wartość wstawi ją w miejsce zapisu `potega()`, wróci do stanu pierwotnego i będzie dalej wykonywał program.
 
-Prześledźmy to na dwóch prostych przykładach. Jak zadziała wywołanie `potega(5,2)`? Najpierw sprawdzi, czy  `n ` jest równe  `1` – nie jest. Potem trzeba obliczyć wartość zmiennej  `s` przez wywołanie  `potega(5,1)`. Zapamiętujemy zatem, że byliśmy w wierszu 5 wywołania funkcji  `potega(5,2)`, aby za chwilę tam powrócić, i rozpoczynamy wykonywanie  `potega(5,1)`. To wywołanie skończy się bardzo szybko: dla niego  `a = 5`, oraz  `n = 1`, więc już po pierwszych dwóch wierszach wiemy, że trzeba zwrócić wartość 5.
+Prześledźmy to na dwóch prostych przykładach. Jak zadziała wywołanie `potega(5,2)`? Najpierw sprawdzi, czy `n ` jest równe `1` – nie jest. Potem trzeba obliczyć wartość zmiennej `s` przez wywołanie `potega(5,1)`. Zapamiętujemy zatem, że byliśmy w wierszu 5 wywołania funkcji `potega(5,2)`, aby za chwilę tam powrócić, i rozpoczynamy wykonywanie `potega(5,1)`. To wywołanie skończy się bardzo szybko: dla niego `a = 5`, oraz `n = 1`, więc już po pierwszych dwóch wierszach wiemy, że trzeba zwrócić wartość 5.
 
-Skoro wiemy już, że  `potega(5,1) = 5,` wracamy z powrotem tam, gdzie byliśmy – do wiersza 5 wywołania  `potega(5,1)`. Obliczoną wartość  `s = 5` należy teraz domnożyć przez  `a` i zwrócić iloczyn `25` – widzimy, że jest to właściwy rezultat działania $5^2$.
+Skoro wiemy już, że `potega(5,1) = 5,` wracamy tam, gdzie byliśmy – do wiersza 5 wywołania `potega(5,1)`. Obliczoną wartość `s = 5` należy teraz domnożyć przez `a` i zwrócić iloczyn `25` – widzimy, że jest to właściwy rezultat działania $5^2$.
 
 Rozważmy teraz wywołanie  `potega(4,3)`. Potrzeba do niego obliczyć wartość  `potega(4,2)`(a potem domnożyć ją przez 4). Wykonujemy zatem  `potega(4,2)`, w którym napotykamy na konieczność obliczenia  `potega(4,1)`. To ostatnie potrafimy obliczyć od razu: jest równe  `4`. Teraz w funkcji  `potega(4,2)` wstawiamy obliczoną wartość jako  `s` i otrzymujemy wynik funkcji  `16`. Wreszcie, wracamy do wiersza 5 w funkcji  `potega(4,3)` domnażamy otrzymaną liczbę `16` przez  `4 ` i dostajemy ostateczny wynik  `64`.
 
-Wywołanie funkcji wewnątrz siebie samej nazywane jest **wywołaniem rekurencyjnym**, a sama technka rozwiązywania problemu przez sprowadzenie go do mniejszej, prostszej wersji tego samego problemu nazywa się  **rekurencją** lub **rekursją**. Aby rekurencja mogła działać, konieczne są trzy warunki:
+Wywołanie funkcji wewnątrz siebie samej nazywane jest **wywołaniem rekurencyjnym**, a sama technika rozwiązywania problemu przez sprowadzenie go do mniejszej, prostszej wersji tego samego problemu nazywa się **rekurencją** lub **rekursją**. Aby rekurencja mogła działać, konieczne są trzy warunki:
 
-- Musimy mieć pewność, że rekursja się zakończy – najczęściej sprowadza się to do faktu, że nowe wywołanie dostaje w pewien sposób "prostsze" dane. Na przykład nasze wywołanie  `potega(a,n)` odwołuje się do  `potega(a,n-1)`, zatem zawsze zmniejsza wykładnik.
-- Musimy wiedzieć, jak z częściowego wyniku – rezultatu wywołania rekurencyjnego – otrzymać wynik, o który chodziło. W tym wypadku wiemy, jak z wartości `potega(a,n-1)` otrzymać  `potega(a,n)` – wystarczy domnożyć pierwszą wartość przez  `a`.
-- Musimy wiedzieć, jak bezpośrednio otrzymać wynik dla najprostszego przypadku, do którego prędzej czy później "dojdzie" rekurencja. Dla powyższej funkcji jest to przepis, jak postąpić dla  `n = 1`.
+- Musimy mieć pewność, że rekursja się zakończy – najczęściej sprowadza się to do faktu, że nowe wywołanie dostaje w pewien sposób "prostsze" dane. Na przykład nasze wywołanie `potega(a,n)` odwołuje się do  `potega(a,n-1)`, zatem zawsze zmniejsza wykładnik.
+- Musimy wiedzieć, jak z częściowego wyniku – rezultatu wywołania rekurencyjnego – otrzymać wynik, o który chodziło. W tym wypadku wiemy, jak z wartości `potega(a,n-1)` otrzymać `potega(a,n)` – wystarczy domnożyć pierwszą wartość przez `a`.
+- Musimy wiedzieć, jak bezpośrednio otrzymać wynik dla najprostszego przypadku, do którego prędzej czy później "dojdzie" rekurencja. Dla powyższej funkcji jest to przepis, jak postąpić dla `n = 1`.
 
-Spróbujmy rozwiązać za pomocą rekursji jakiś inny problem – na przykład obliczyć funkcję silnia. Przypomnimy, że oznacza się ją symbolem wykrzyknika, a definuje nastąpująco: 
+Spróbujmy rozwiązać za pomocą rekursji jakiś inny problem – na przykład obliczyć funkcję silnia. Przypomnimy, że oznacza się ją symbolem wykrzyknika, a definiuje następująco:
 
-$n! = 1 \cdot 2 \cdot \ldots \cdot n$. 
+$n! = 1 \cdot 2 \cdot \ldots \cdot n$.
 
 Na przykład $3! = 1 \cdot 2 \cdot 3 = 6$. Silnię można oczywiście obliczyć prostą pętlą, można jednak też zauważyć, że zawsze zachodzi $n! = 1 \cdot 2 \cdot \ldots \cdot (n-1) \cdot n = (n-1)! \cdot n$. To pozwala napisać taką funkcję:
 
@@ -66,7 +66,7 @@ int silnia(int n) {
 
 ## Szybkie potęgowanie
 
-Wróćmy na chwilę do potęgowania. W rekurencyjnej wersji skorzystaliśmy z faktu, że aby obliczyć $a^n$, wystarczy mieć $a^{n-1}$, a następnie domnożyć je przez $a$. Można w tej obserwacji pójść dalej – dla parzystych $n$, liczba $a^n$ jest kwadratem $a^{n/2}$, na przykład liczbę $2^{12}$ można otrzymać, podnosząc do kwadratu liczbę $2^6$. Zmieńmy zatem trochę zachowanie programu programu w przypadku parzystego wykładnika:
+Wróćmy na chwilę do potęgowania. W rekurencyjnej wersji skorzystaliśmy z faktu, że aby obliczyć $a^n$, wystarczy mieć $a^{n-1}$, a następnie domnożyć je przez $a$. Można w tej obserwacji pójść dalej – dla parzystych $n$, liczba $a^n$ jest kwadratem $a^{n/2}$, na przykład liczbę $2^{12}$ można otrzymać, podnosząc do kwadratu liczbę $2^6$. Zmieńmy zatem trochę zachowanie programu w przypadku parzystego wykładnika:
 
 ```cpp
 int potega(int a, int n) {
@@ -85,11 +85,11 @@ int potega(int a, int n) {
 }
 ```
 
-Ta wersja ma wprawdzie dłuższy kod, ale znacznie przewyższa poprzednią pod względem efektywności działania. Aby na przykład obliczyć  `potega(2,20)`, wywoła  `potega(2,10)`, potem  `potega(2,5), potega(2,4), potega(2,2) ` i wreszcie  `potega(2,1)`. Z każdym wywołaniem (poza ostatnim) związana jest jedna operacja mnożenia, zatem osiągniemy wynik wykonując tylko 5 (zamiast 20) mnożeń. Różnica ta staje się jeszcze bardziej widoczna dla dużych wykładników: dla  `n = 1000` wykonamy zaledwie kilkanaście mnożeń, zamiast tysiąca.
+Ta wersja ma wprawdzie dłuższy kod, ale znacznie przewyższa poprzednią pod względem efektywności działania. Aby na przykład obliczyć `potega(2,20)`, wywoła `potega(2,10)`, potem `potega(2,5), potega(2,4), potega(2,2)` i wreszcie `potega(2,1)`. Z każdym wywołaniem (poza ostatnim) związana jest jedna operacja mnożenia, zatem osiągniemy wynik, wykonując tylko 5 (zamiast 20) mnożeń. Różnica ta staje się jeszcze bardziej widoczna dla dużych wykładników: dla  `n = 1000` wykonamy zaledwie kilkanaście mnożeń, zamiast tysiąca.
 
-Można pokusić się o dokładniejsze oszacowanie czasu działania algorytmu. Dla uproszczenia pozostańmy przy liczeniu wyłącznie tego, ile wykonaliśmy mnożeń, jako że innych operacji jest mniej–więcej tyle samo w programie. To z kolei zależy od tego, ile było wywołań rekurencyjnych – na każde wywołanie przypada jedna operacja mnożenia. Każde następne wywołanie ma wykładnik albo dwa razy mniejszy (jeśli $n$ było parzyste), albo o jeden mniejszy (dla $n$ nieparzystych) od poprzedniego, jednak ten drugi przypadek - przejście od  $n$ do  $n-1$ nie może zdarzyć się dwa razy z rzędu. Jeśli bowiem  $n$ było nieparzyste, to  $n-1$ będzie parzyste, i następne wywołanie podzieli wykładnik przez 2.
+Można pokusić się o dokładniejsze oszacowanie czasu działania algorytmu. Dla uproszczenia pozostańmy przy liczeniu wyłącznie tego, ile wykonaliśmy mnożeń, jako że innych operacji jest mniej–więcej tyle samo w programie. To z kolei zależy od tego, ile było wywołań rekurencyjnych – na każde wywołanie przypada jedna operacja mnożenia. Każde następne wywołanie ma wykładnik albo dwa razy mniejszy (jeśli $n$ było parzyste), albo o jeden mniejszy (dla $n$ nieparzystych) od poprzedniego, jednak ten drugi przypadek – przejście od $n$ do $n-1$ nie może zdarzyć się dwa razy z rzędu. Jeśli bowiem  $n$ było nieparzyste, to  $n-1$ będzie parzyste, i następne wywołanie podzieli wykładnik przez 2.
 
-Widać więc, że każde jedno lub dwa kolejne wywołania zmniejszają wykładnik  $n$ dwukrotnie.
+Widać więc, że każde jedno lub dwa kolejne wywołania zmniejszają wykładnik $n$ dwukrotnie.
 Wiemy z poprzednich lekcji, że liczbę $n$ można dzielić przez 2 dokładnie $\lceil \log_2 n \rceil$ razy,
 zanim osiągniemy 1. A zatem w tym wypadku wywołań będzie co najmniej $\lceil \log_2 n \rceil$,
 a co najwyżej $2 \cdot \lceil \log_2 n \rceil$.
@@ -101,7 +101,7 @@ Dlatego ten algorytm nazywa się najczęściej **szybkim potęgowaniem** (funkcj
 
 Bardzo znanym problemem algorytmicznym jest obliczenie największego wspólnego dzielnika dwóch podanych liczb. Formalnie: mając dane dwie liczby naturalne $a$ i $b$, znaleźć największą liczbę $d$ dzielącą obie. Jednym z możliwych podejść do tego zagadnienia, czasem spotykanym w szkołach, jest rozkład obu liczb na czynniki pierwsze, a następnie wzięcie wspólnych elementów tych rozkładów. Z punktu widzenia algorytmiki jednak sposób ten jest wyjątkowo niefortunny, rozkład na czynniki jest (jak przekonamy się za parę lekcji) dość trudnym obliczeniowo zadaniem. Praktycznie niemożliwe – przy obecnym stanie wiedzy ludzkości – jest rozłożenie w rozsądnym czasie dużej liczby na czynniki pierwsze, za to największy wspólny dzielnik można obliczyć bardzo szybko, dzięki algorytmowi znanemu jako **algorytm Euklidesa**.
 
-Algorytm Euklidesa opiera się na bardzo prostej obserwacji: jeśli jakaś liczba $d$ dzieli dwie liczby  $a$ i $b$, dzieli też ich różnicę $a - b$. Jest też w pewnym sensie odwrotnie – jeśli wspólny dzielnik mają $b$ oraz $a - b$, posiada go z całą pewnością także $a$. To oznacza, że zamiast liczb $a$ i $b$ możemy równie dobrze wziąć $a - b$ oraz $b$. Na przykład, jeśli szukamy wspólnego dzielnika dla pary (39,65) możemy zamiast tych dwóch liczb wziąć 65-39 = 26 oraz mniejszą z dwóch liczb 39. Parę (39,26) w ten sam sposób sprowadzamy do (26,13), potem do (13,13) i ewentualnie do (13,0). Największy wspólny dzielnik liczby i zera to zawsze ta sama liczba – wiemy zatem, że wynik wynosi 13. Ten sposób postępowania można oczywiście zaprogramować za pomocą pętli. Zwróćmy jednak uwagę, że  rekursja pasuje tu wręcz idealnie: potrafimy sprowadzić zadanie do prostszego (parę $(a,b)$ do pary $(b,a-b)$), wiemy jak z "pośredniego" wyniku otrzymać "końcowy" (największy wspólny dzielnik jest po prostu taki sam), oraz wiemy, jak obsłużyć przypadek końcowy (dla pary $(a,0)$ wynikiem jest $a$). Implementacja rekurencyjna okazuje się zatem bardzo prosta:
+Algorytm Euklidesa opiera się na bardzo prostej obserwacji: jeśli jakaś liczba $d$ dzieli dwie liczby  $a$ i $b$, dzieli też ich różnicę $a - b$. Jest też w pewnym sensie odwrotnie – jeśli wspólny dzielnik mają $b$ oraz $a - b$, posiada go z całą pewnością także $a$. To oznacza, że zamiast liczb $a$ i $b$ możemy równie dobrze wziąć $a - b$ oraz $b$. Na przykład, jeśli szukamy wspólnego dzielnika dla pary (39,65) możemy zamiast tych dwóch liczb wziąć 65-39 = 26 oraz mniejszą z dwóch liczb 39. Parę (39,26) w ten sam sposób sprowadzamy do (26,13), potem do (13,13) i ewentualnie do (13,0). Największy wspólny dzielnik liczby i zera to zawsze ta sama liczba – wiemy zatem, że wynik wynosi 13. Ten sposób postępowania można oczywiście zaprogramować za pomocą pętli. Zwróćmy jednak uwagę, że  rekursja pasuje tu wręcz idealnie: potrafimy sprowadzić zadanie do prostszego (parę $(a,b)$ do pary $(b,a-b)$) wiemy, jak z "pośredniego" wyniku otrzymać "końcowy" (największy wspólny dzielnik jest po prostu taki sam), oraz wiemy, jak obsłużyć przypadek końcowy (dla pary $(a,0)$ wynikiem jest $a$). Implementacja rekurencyjna okazuje się zatem bardzo prosta:
 
 ```cpp
 int nwd(int a, int b) {
@@ -113,7 +113,7 @@ int nwd(int a, int b) {
 }
 ```
 
-Niestety, program w tej wersji nie zadziała jeszcze poprawnie – tak naprawdę nie chcemy odejmować $b$ od $a$, tylko _mniejszą_ z liczb od _większej_. Bardzo łatwo jednak poprawić algorytm, aby upewnić się, że zawsze a jest większe, zaś b mniejsze, po prostu zamieniając liczby miejscami w razie potrzeby:
+Niestety, program w tej wersji nie zadziała jeszcze poprawnie – tak naprawdę nie chcemy odejmować $b$ od $a$, tylko _mniejszą_ z liczb od _większej_. Bardzo łatwo jednak poprawić algorytm, aby upewnić się, że zawsze $a$ jest większe, $b$ zaś mniejsze, po prostu zamieniając liczby miejscami w razie potrzeby:
 
 ```cpp
 int nwd(int a, int b) {
@@ -127,7 +127,7 @@ int nwd(int a, int b) {
 }
 ```
 
-Algorytm daje już dobre wyniki, ale może się zdarzyć, że będzie działał powoli: na przykład dla pary (10003, 4) będzie 2500 razy odejmował mniejszą liczbę od większej. Aby tego uniknąć, zauważmy, że wynikiem wielokrotnego odejmowania mniejszej liczby  $b$ od większej  $a$, jest ostatecznie reszta z dzielenia  $a$ przez  $b$ (w wyżej wymienionym przykładzie widzimy, że po odjęciu 4 odpowiednią liczbę razy od 10003 otrzymamy 3 – taki sam wynik, jak gdybyśmy od razu podzielili z resztą 10003 przez 4). Zamiast więc liczyć kilka razy różnicę  $a-b$, można od razu przeskoczyć parę kroków zastępując różnicę przez wspomnianą resztę:
+Algorytm daje już dobre wyniki, ale może się zdarzyć, że będzie działał powoli: na przykład dla pary (10003, 4) będzie 2500 razy odejmował mniejszą liczbę od większej. Aby tego uniknąć, zauważmy, że wynikiem wielokrotnego odejmowania mniejszej liczby $b$ od większej $a$, jest ostatecznie reszta z dzielenia $a$ przez $b$ (w wyżej wymienionym przykładzie widzimy, że po odjęciu odpowiednią liczbę razy 4 od 10003 otrzymamy 3 – taki sam wynik, jak gdybyśmy od razu podzielili z resztą 10003 przez 4). Zamiast więc liczyć kilka razy różnicę $a-b$, można od razu przeskoczyć parę kroków, zastępując różnicę przez wspomnianą resztę:
 
 ```cpp
 int nwd(int a, int b) {
@@ -141,7 +141,7 @@ int nwd(int a, int b) {
 }
 ```
 
-Jak szybko działa ten algorytm? Przy każdym wywołaniu rekurencyjnym liczba  $a$ (większa) jest zastępowana liczbą  $a \% b$, która jest od niej (co nietrudno pokazać) przynajmniej dwukrotnie mniejsza.
+Jak szybko działa ten algorytm? Przy każdym wywołaniu rekurencyjnym liczba $a$ (większa) jest zastępowana liczbą $a \% b$, która jest od niej (co nietrudno pokazać) przynajmniej dwukrotnie mniejsza.
 Wiemy zatem, że każde wywołanie zmniejsza przynajmniej dwukrotnie jedną z liczb.
 Nie może być zatem więcej niż $\log a + \log b$ wywołań
 (bo nie może być więcej niż $\log a$ zmniejszeń  $a$ i $\log b$ zmniejszeń  $b$).

--- a/docs/B-proste-algorytmy/B6-sortowanie.md
+++ b/docs/B-proste-algorytmy/B6-sortowanie.md
@@ -6,7 +6,7 @@ Popularny (i bardzo naturalny) problem sortowania formułuje się w następując
 w najprostszej wersji, liczb całkowitych. Chcemy tak przestawić elementy,
 aby były one ustawione w kolejności niemalejącej.**
 
-Algorytmów sortowania jest bardzo wiele, różnią się one szybkością działania, prostotą implementacji oraz sytuacjami w jakich można je stosować. W tym rozdziale omówimy szczegółowo trzy proste algorytmy sortowania. W dalszych rozdziałach powrócimy do tematu, aby pokazać algorytmy, które okażą się bardziej efektywne, ale też bardziej skomplikowane.
+Algorytmów sortowania jest bardzo wiele, różnią się one szybkością działania, prostotą implementacji oraz sytuacjami, w jakich można je stosować. W tym rozdziale omówimy szczegółowo trzy proste algorytmy sortowania. W dalszych rozdziałach powrócimy do tematu, aby pokazać algorytmy, które okażą się bardziej efektywne, ale też bardziej skomplikowane.
 
 ## Sortowanie bąbelkowe
 
@@ -41,7 +41,7 @@ for(int i = 0; i < n-1; i++) {
 Jak widać na powyższym przykładzie, nie wystarczy to do posortowania wszystkich elementów. Zauważmy jednak, że największy
 element tablicy musi po takiej pętli trafić na koniec – od miejsca, na którym stoi, będzie już za każdym razem zamieniany z następnym. Jeśli teraz
 powtórzymy procedurę, na przedostatnie miejsce w tablicy trafi drugi w kolejności element. Wystarczy zatem powtórzyć powyższą pętlę $n$ razy, aby mieć
-pewnośc, że na swoich miejscach znajdą się wszystkie elementy w tablicy:
+pewność, że na swoich miejscach znajdą się wszystkie elementy w tablicy:
 
 ```cpp
 for(int k = 0; k < n; k++) {
@@ -53,9 +53,9 @@ for(int k = 0; k < n; k++) {
 }
 ```
 
-Można jeszcze zauważyć dwa szczegóły: po pierwsze, wystarczy  $n-1$ przebiegów – jeśli  $n-1$ elementów jest na swoich miejscach, ostatni nie
+Można jeszcze zauważyć dwa szczegóły: po pierwsze, wystarczy $n-1$ przebiegów – jeśli $n-1$ elementów jest na swoich miejscach, ostatni nie
 ma innej możliwości. Po drugie, skoro po pierwszym "przebiegu" na końcu jest ostatni element, można już go nie sprawdzać w dalszych iteracjach. Drugą pętlę
-wystarczy wykonać do elementu  $n-2$, trzecią do  $n-3$, i tak dalej. Ostateczna wersja algorytmu wygląda zatem następująco:
+wystarczy wykonać do elementu $n-2$, trzecią do $n-3$, i tak dalej. Ostateczna wersja algorytmu wygląda zatem następująco:
 
 ```cpp
 for(int k = 0; k < n-1; k++) {
@@ -67,7 +67,7 @@ for(int k = 0; k < n-1; k++) {
 }
 ```
 
-Spróbujmy określić złożoność obliczeniową tego algorytmu. Aby to zrobić, musimy najpierw wybrać najczęściej występującą instrukcję: tradycyjnie przy algorytmach sortowania liczy się porówania, czyli instrukcje postaci `if (x > y) ...` – tak i my postąpimy tym razem, jako że w naszym algorytmie porównanie występuje w każdej iteracji pętli. Alternatywą byłoby np. liczenie przestawień elementów w tablicy – zauważmy, że w na każde porównanie (`if (A[i] > A[i + 1])`) przypada w pesymistycznym wypadku jedno przestawienie (`swap(A[i], A[i + 1])`), więc wynik byłby ten sam.
+Spróbujmy określić złożoność obliczeniową tego algorytmu. Aby to zrobić, musimy najpierw wybrać najczęściej występującą instrukcję: tradycyjnie przy algorytmach sortowania liczy się porównania, czyli instrukcje postaci `if (x > y) ...` – tak i my postąpimy tym razem, jako że w naszym algorytmie porównanie występuje w każdej iteracji pętli. Alternatywą byłoby np. liczenie przestawień elementów w tablicy – zauważmy, że w na każde porównanie (`if (A[i] > A[i + 1])`) przypada w pesymistycznym wypadku jedno przestawienie (`swap(A[i], A[i + 1])`), więc wynik byłby ten sam.
 
 Dla tablicy o wielkości $n$ wykonujemy $n-1$ porównań w pierwszym obrocie pętli, $n-2$ w drugim, ..., aż do jednego porównania w ostatnim obrocie. Całkowita złożoność wynosi zatem:
 
@@ -113,7 +113,7 @@ for (int j = 0; j < n-1; j++) {
 }
 ```
 
-Jeśli tutaj policzymy instrukcje porównania `if (A[i] > A[k])`, złożoność wyjedzie identyczna jak w sortowaniu bąbelkowym:
+Jeśli tutaj policzymy instrukcje porównania `if (A[i] > A[k])`, złożoność wyjedzie identyczna, jak w sortowaniu bąbelkowym:
 
 \[
   n-1 + n-2 + \ldots + 1 = \frac{n(n-1)}{2} = \frac{1}{2}n^2 - \frac{1}{2}n.
@@ -121,7 +121,7 @@ Jeśli tutaj policzymy instrukcje porównania `if (A[i] > A[k])`, złożoność 
 
 ## Sortowanie przez wstawianie
 
-Wyobraźmy sobie, że początkowa część tablicy – pierwsze $k$ elementów – stoi już we właściwej kolejności, czyli jest posortowana. Idea, na której opiera się nowy algorytm sortowania jest następująca: stosunkowo łatwo jest wstawić nowy element w ten już posortowany ciąg. Po prostu przesuwamy go w lewo, zamieniając z następnym elementem, tak długo aż trafi na swoje miejsce:
+Wyobraźmy sobie, że początkowa część tablicy – pierwsze $k$ elementów – stoi już we właściwej kolejności, czyli jest posortowana. Idea, na której opiera się nowy algorytm sortowania, jest następująca: stosunkowo łatwo jest wstawić nowy element w ten już posortowany ciąg. Po prostu przesuwamy go w lewo, zamieniając z następnym elementem, tak długo aż trafi na swoje miejsce:
 
 ```cpp
 
@@ -181,6 +181,6 @@ for(int k = 1; k < n; k++) {			// Ten sam algorytm, co powyżej...
 
 ```
 
-Jak poprzednio, policzmy instrukcje porównania `A[j] < A[j+1]` w zależności od długości tablicy $n$. Najbardziej pesymistyczna sytuacja ma miejsce, kiedy każdy element musimy wstawiać na sam początek, zamieniając ze wszystkimi poprzednimi. Liczba operacji, liczona pesymistycznie, będzie wtedy taka sama, jak w dwóch poprzednich algorytmach ($\frac{n(n-1)}{2}$). Sortowanie przez wstawianie ma jednak dużą zaletę – działa znacznie szybciej jeśli dane już są częściowo posortowane. O ile formalnie jest to również algorytm kwadratowy, jak poprzednie dwa, o tyle w praktyce stosowany jest częściej.
+Jak poprzednio, policzmy instrukcje porównania `A[j] < A[j+1]` w zależności od długości tablicy $n$. Najbardziej pesymistyczna sytuacja ma miejsce, kiedy każdy element musimy wstawiać na sam początek, zamieniając ze wszystkimi poprzednimi. Liczba operacji, liczona pesymistycznie, będzie wtedy taka sama, jak w dwóch poprzednich algorytmach ($\frac{n(n-1)}{2}$). Sortowanie przez wstawianie ma jednak dużą zaletę – działa znacznie szybciej, jeśli dane już są częściowo posortowane. O ile formalnie jest to również algorytm kwadratowy, jak poprzednie dwa, o tyle w praktyce stosowany jest częściej.
 
 


### PR DESCRIPTION
Merytorycznie nic się nie zmieniło. Poprawiłem małe błędy, w tym najczęstsze:
- Używanie minusa lub dwóch minusów jako myślników
- Błędne używanie słów "zaś" i "bowiem" na początku zdania podrzędnego
- Rozpoczynanie zdania od "Ale"
- Brakujące, nadmiarowe i źle umieszczone przecinki
- Anglicyzm "dodatkowo" (zastąpiony polskim sformułowaniem "co więcej")
- Liczebniki porządkowe zapisywane z myślnikiem
- Literówki
- Wielokrotne spacje oraz białe znaki na końcu linii